### PR TITLE
Track trace storage loss counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ records. Nesting is important data, but it should not dominate the first diagnos
 Capture-time filtering is still useful for cost control. Display-time filtering is the main
 interaction model for diagnostics inside a running TUI.
 
+`TraceStore::status()` exposes cheap storage counters for status bars and diagnostics: configured
+capacity, retained events, retained spans, captured events, accepted events, evicted events, and
+dropped events. These counters describe storage behavior before display-time filtering, so hiding
+an event with `TraceFilter` does not change the captured, evicted, or dropped totals.
+
 ## Basic Usage
 
 ```rust
@@ -71,7 +76,7 @@ still preserving correct follow-tail and scrollback behavior.
 ## Current Public Path
 
 - `TraceLayer`: subscriber layer for capture.
-- `TraceStore`: shared runtime buffer of retained records.
+- `TraceStore`: shared runtime buffer of retained records and storage counters.
 - `TraceViewer`: Ratatui event-stream viewer.
 - `TraceFilter`: display-time event filter.
 - `TimingLayer`: optional span busy/idle timing layer.
@@ -86,9 +91,8 @@ path above.
   views.
 - The timing layer remains local to this crate. The related upstream tracing PR did not appear to
   land as a stable `tracing-subscriber` API.
-- Selection, expanded details, grouped rows, dropped-record accounting, page movement, and status
+- Selection, expanded details, grouped rows, page movement, and higher-level viewer status
   summaries are planned follow-up work rather than part of the initial viewer surface.
-- No MSRV is declared yet.
 
 The follow-up work is tracked in the
 [main trace viewer roadmap](https://github.com/joshka/tui-tracing/issues/22).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,8 @@
 //! # Core Concepts
 //!
 //! - [`TraceLayer`] captures structured tracing records.
-//! - [`TraceStore`] retains those records for runtime inspection.
+//! - [`TraceStore`] retains those records for runtime inspection and exposes storage counters
+//!   through [`TraceStore::status`].
 //! - [`TraceFilter`] filters retained records at display time without losing data.
 //! - [`TraceViewer`] renders the event-stream view and owns scroll/filter state.
 //! - [`TimingLayer`] optionally records span busy/idle timing.
@@ -117,6 +118,6 @@ pub use filter::TraceFilter;
 pub use format::FormatOptions;
 pub use layer::{TraceLayer, TracingLayer};
 pub use record::{EventId, EventRecord, Level, SpanId, SpanRecord};
-pub use store::{TraceSnapshot, TraceStore};
+pub use store::{TraceSnapshot, TraceStore, TraceStoreStatus};
 pub use timing_layer::{Timing, TimingLayer};
 pub use viewer::TraceViewer;

--- a/src/store.rs
+++ b/src/store.rs
@@ -3,6 +3,11 @@
 //! [`TraceStore`] is the handoff point between the tracing subscriber layer and TUI
 //! rendering. The subscriber writes complete structured records, and the application
 //! reads snapshots later for display-time filtering.
+//!
+//! Event retention is bounded FIFO storage. When the event buffer reaches capacity,
+//! the oldest retained event is evicted before the new event is retained. A capacity
+//! of zero drops all events at insertion time while still allowing span metadata to
+//! be recorded. These storage counters are independent of display-time filtering.
 
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -41,6 +46,10 @@ impl TraceStore {
             inner: Arc::new(RwLock::new(TraceStoreInner {
                 event_capacity,
                 next_event_id: 0,
+                captured_events: 0,
+                accepted_events: 0,
+                evicted_events: 0,
+                dropped_events: 0,
                 events: VecDeque::with_capacity(event_capacity),
                 spans: IndexMap::new(),
             })),
@@ -53,14 +62,28 @@ impl TraceStore {
         TraceSnapshot {
             events: inner.events.iter().cloned().collect(),
             spans: inner.spans.clone(),
+            status: inner.status(),
         }
     }
 
-    /// Remove all retained events and spans.
+    /// Return cheap storage counters without cloning retained records.
+    ///
+    /// These counters describe what reached the store before display-time filtering.
+    /// A hidden event still contributes to the counters if it was captured and
+    /// retained, evicted, or dropped by storage capacity.
+    pub fn status(&self) -> TraceStoreStatus {
+        self.inner.read().status()
+    }
+
+    /// Remove all retained events and spans and reset storage counters.
     pub fn clear(&self) {
         let mut inner = self.inner.write();
         inner.events.clear();
         inner.spans.clear();
+        inner.captured_events = 0;
+        inner.accepted_events = 0;
+        inner.evicted_events = 0;
+        inner.dropped_events = 0;
     }
 
     /// Return the configured event capacity.
@@ -102,19 +125,43 @@ impl TraceStore {
 struct TraceStoreInner {
     event_capacity: usize,
     next_event_id: EventId,
+    captured_events: usize,
+    accepted_events: usize,
+    evicted_events: usize,
+    dropped_events: usize,
     events: VecDeque<EventRecord>,
     spans: IndexMap<SpanId, SpanRecord>,
 }
 
 impl TraceStoreInner {
     fn push_event(&mut self, event: EventRecord) {
+        self.captured_events += 1;
+
         if self.event_capacity == 0 {
+            self.dropped_events += 1;
             return;
         }
+
+        self.accepted_events += 1;
+
         if self.events.len() == self.event_capacity {
             self.events.pop_front();
+            self.evicted_events += 1;
         }
+
         self.events.push_back(event);
+    }
+
+    fn status(&self) -> TraceStoreStatus {
+        TraceStoreStatus {
+            event_capacity: self.event_capacity,
+            retained_events: self.events.len(),
+            retained_spans: self.spans.len(),
+            captured_events: self.captured_events,
+            accepted_events: self.accepted_events,
+            evicted_events: self.evicted_events,
+            dropped_events: self.dropped_events,
+        }
     }
 }
 
@@ -126,4 +173,49 @@ pub struct TraceSnapshot {
 
     /// Spans retained by the store, keyed by span identifier.
     pub spans: IndexMap<SpanId, SpanRecord>,
+
+    /// Storage counters captured at the same time as the retained records.
+    pub status: TraceStoreStatus,
+}
+
+/// Cheap summary of retained trace storage and storage-level event loss.
+///
+/// Counts are measured since store creation or the last [`TraceStore::clear`].
+/// Display-time filtering does not change these values. `dropped_events` counts
+/// events that reached the store but could not be retained at insertion time; with
+/// the current FIFO policy, that only happens when event capacity is zero.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct TraceStoreStatus {
+    /// Maximum number of events retained by this store.
+    pub event_capacity: usize,
+
+    /// Number of events currently retained by this store.
+    pub retained_events: usize,
+
+    /// Number of spans currently retained by this store.
+    pub retained_spans: usize,
+
+    /// Number of events passed to this store.
+    pub captured_events: usize,
+
+    /// Number of captured events accepted into storage.
+    pub accepted_events: usize,
+
+    /// Number of previously retained events removed because capacity was reached.
+    pub evicted_events: usize,
+
+    /// Number of captured events discarded before being retained.
+    pub dropped_events: usize,
+}
+
+impl TraceStoreStatus {
+    /// Return the total number of captured events that are no longer retained.
+    pub fn lost_events(self) -> usize {
+        self.evicted_events + self.dropped_events
+    }
+
+    /// Return `true` when no events are currently retained.
+    pub fn is_empty(self) -> bool {
+        self.retained_events == 0
+    }
 }

--- a/tests/public_workflow.rs
+++ b/tests/public_workflow.rs
@@ -6,6 +6,94 @@ use tracing_subscriber::Registry;
 use tui_tracing::{FieldValue, TraceFilter, TraceLayer, TraceStore, TraceViewer};
 
 #[test]
+fn store_status_tracks_empty_capacity_as_dropped_events() {
+    let store = TraceStore::with_capacity(0);
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        tracing::info!("not retained");
+        tracing::warn!("also not retained");
+    });
+
+    let status = store.status();
+    assert_eq!(status.event_capacity, 0);
+    assert_eq!(status.captured_events, 2);
+    assert_eq!(status.accepted_events, 0);
+    assert_eq!(status.retained_events, 0);
+    assert_eq!(status.evicted_events, 0);
+    assert_eq!(status.dropped_events, 2);
+    assert_eq!(status.lost_events(), 2);
+    assert!(status.is_empty());
+}
+
+#[test]
+fn store_status_tracks_retained_events_without_eviction() {
+    let store = TraceStore::with_capacity(3);
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        let span = tracing::info_span!("request");
+        let _guard = span.enter();
+        tracing::info!("one");
+        tracing::info!("two");
+    });
+
+    let status = store.status();
+    assert_eq!(status.event_capacity, 3);
+    assert_eq!(status.captured_events, 2);
+    assert_eq!(status.accepted_events, 2);
+    assert_eq!(status.retained_events, 2);
+    assert_eq!(status.retained_spans, 1);
+    assert_eq!(status.evicted_events, 0);
+    assert_eq!(status.dropped_events, 0);
+    assert_eq!(status.lost_events(), 0);
+
+    let snapshot = store.snapshot();
+    assert_eq!(snapshot.status, status);
+}
+
+#[test]
+fn store_status_tracks_fifo_eviction_and_clear_reset() {
+    let store = TraceStore::with_capacity(2);
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        tracing::info!("one");
+        tracing::info!("two");
+        tracing::info!("three");
+    });
+
+    let status = store.status();
+    assert_eq!(status.captured_events, 3);
+    assert_eq!(status.accepted_events, 3);
+    assert_eq!(status.retained_events, 2);
+    assert_eq!(status.evicted_events, 1);
+    assert_eq!(status.dropped_events, 0);
+    assert_eq!(status.lost_events(), 1);
+
+    let snapshot = store.snapshot();
+    assert_eq!(snapshot.events.len(), 2);
+    assert_eq!(
+        snapshot.events[0].fields.get("message"),
+        Some(&FieldValue::Debug("two".to_owned()))
+    );
+    assert_eq!(
+        snapshot.events[1].fields.get("message"),
+        Some(&FieldValue::Debug("three".to_owned()))
+    );
+
+    store.clear();
+    assert_eq!(
+        store.status(),
+        tui_tracing::TraceStoreStatus {
+            event_capacity: 2,
+            ..Default::default()
+        }
+    );
+    assert!(store.snapshot().events.is_empty());
+}
+
+#[test]
 fn capture_preserves_span_context_and_field_only_events() {
     let store = TraceStore::default();
     let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));


### PR DESCRIPTION
## Summary

- add `TraceStoreStatus` and `TraceStore::status()` for cheap storage counters
- include snapshot-consistent status in `TraceSnapshot`
- track captured, accepted, evicted, dropped, retained event, and retained span counts
- reset storage counters on `TraceStore::clear()`
- document that display-time filtering does not affect storage counters

Closes #6.

Follow-up retention policy issue: #25

## Validation

- `just ci`
