### PR TITLE
Expose retention status helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ interaction model for diagnostics inside a running TUI.
 `TraceStore::status()` exposes cheap storage counters for status bars and diagnostics: configured
 capacity, retained events, retained spans, captured events, accepted events, evicted events, and
 dropped events. These counters describe storage behavior before display-time filtering, so hiding
-an event with `TraceFilter` does not change the captured, evicted, or dropped totals.
+an event with `TraceFilter` does not change the captured, evicted, or dropped totals. The returned
+status also has helpers for common status-bar decisions such as empty state, remaining event
+capacity, capacity pressure, and whether any captured event has been lost.
 
 ## Basic Usage
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -214,8 +214,36 @@ impl TraceStoreStatus {
         self.evicted_events + self.dropped_events
     }
 
+    /// Return the number of additional events this store can retain before eviction.
+    ///
+    /// This is a point-in-time storage summary. Concurrent capture can make the
+    /// value stale immediately after it is read.
+    pub fn remaining_event_capacity(self) -> usize {
+        self.event_capacity.saturating_sub(self.retained_events)
+    }
+
     /// Return `true` when no events are currently retained.
     pub fn is_empty(self) -> bool {
         self.retained_events == 0
+    }
+
+    /// Return `true` when the retained event buffer has reached its configured capacity.
+    pub fn is_at_event_capacity(self) -> bool {
+        self.retained_events == self.event_capacity
+    }
+
+    /// Return `true` when any captured event is no longer retained.
+    pub fn has_lost_events(self) -> bool {
+        self.lost_events() > 0
+    }
+
+    /// Return `true` when at least one retained event was evicted by capacity pressure.
+    pub fn has_evicted_events(self) -> bool {
+        self.evicted_events > 0
+    }
+
+    /// Return `true` when at least one captured event was discarded before retention.
+    pub fn has_dropped_events(self) -> bool {
+        self.dropped_events > 0
     }
 }

--- a/tests/public_workflow.rs
+++ b/tests/public_workflow.rs
@@ -23,7 +23,12 @@ fn store_status_tracks_empty_capacity_as_dropped_events() {
     assert_eq!(status.evicted_events, 0);
     assert_eq!(status.dropped_events, 2);
     assert_eq!(status.lost_events(), 2);
+    assert_eq!(status.remaining_event_capacity(), 0);
     assert!(status.is_empty());
+    assert!(status.is_at_event_capacity());
+    assert!(status.has_lost_events());
+    assert!(!status.has_evicted_events());
+    assert!(status.has_dropped_events());
 }
 
 #[test]
@@ -47,6 +52,10 @@ fn store_status_tracks_retained_events_without_eviction() {
     assert_eq!(status.evicted_events, 0);
     assert_eq!(status.dropped_events, 0);
     assert_eq!(status.lost_events(), 0);
+    assert_eq!(status.remaining_event_capacity(), 1);
+    assert!(!status.is_empty());
+    assert!(!status.is_at_event_capacity());
+    assert!(!status.has_lost_events());
 
     let snapshot = store.snapshot();
     assert_eq!(snapshot.status, status);
@@ -70,6 +79,12 @@ fn store_status_tracks_fifo_eviction_and_clear_reset() {
     assert_eq!(status.evicted_events, 1);
     assert_eq!(status.dropped_events, 0);
     assert_eq!(status.lost_events(), 1);
+    assert_eq!(status.remaining_event_capacity(), 0);
+    assert!(!status.is_empty());
+    assert!(status.is_at_event_capacity());
+    assert!(status.has_lost_events());
+    assert!(status.has_evicted_events());
+    assert!(!status.has_dropped_events());
 
     let snapshot = store.snapshot();
     assert_eq!(snapshot.events.len(), 2);
@@ -90,6 +105,9 @@ fn store_status_tracks_fifo_eviction_and_clear_reset() {
             ..Default::default()
         }
     );
+    assert_eq!(store.status().remaining_event_capacity(), 2);
+    assert!(store.status().is_empty());
+    assert!(!store.status().is_at_event_capacity());
     assert!(store.snapshot().events.is_empty());
 }
 


### PR DESCRIPTION
## Summary

- add derived `TraceStoreStatus` helpers for status bars and diagnostics
- expose remaining event capacity, capacity pressure, and event-loss predicates
- extend storage status tests to cover helper behavior before capture, after capture, after eviction, and after clear
- document the status helpers as app-owned status-bar inputs

Closes #7.

## Validation

- `just ci`
