### PR TITLE
Expose structured viewer status

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ through methods such as `set_filter`, `scroll_up`, `scroll_down`, and `follow_ta
 render `&mut viewer` in the area they assign to trace output. This avoids `StatefulWidget` while
 still preserving correct follow-tail and scrollback behavior.
 
+Applications can call `TraceViewer::status()` to build their own status bars without duplicating
+viewer logic. The returned status includes follow-tail versus scrollback mode, the last computed
+scroll offsets, visible and hidden event counts after display filtering, the active filter, and
+the underlying `TraceStoreStatus`.
+
 ## Current Public Path
 
 - `TraceLayer`: subscriber layer for capture.

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -18,7 +18,7 @@ use tracing::{debug, error, info, trace, warn, Level};
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
-use tui_tracing::{TraceFilter, TraceLayer, TraceViewer};
+use tui_tracing::{TraceFilter, TraceLayer, TraceScrollMode, TraceViewStatus, TraceViewer};
 
 fn main() -> Result<()> {
     color_eyre::install()?;
@@ -92,11 +92,8 @@ impl App {
 
         let title =
             Line::from("tui-tracing demo").style(Style::default().add_modifier(Modifier::BOLD));
-        let status = Line::from(format!(
-            "q quit | d level {}+ | Up/Down scroll | End follow tail",
-            self.min_level
-        ))
-        .style(Style::default().add_modifier(Modifier::DIM));
+        let status = demo_status(self.min_level, self.viewer.status())
+            .style(Style::default().add_modifier(Modifier::DIM));
 
         frame.render_widget(Paragraph::new(title), title_area);
         frame.render_widget(&mut self.viewer, trace_area);
@@ -147,6 +144,20 @@ impl App {
             .set_filter(TraceFilter::all().with_min_level(self.min_level));
         info!(visible_level = %self.min_level, "updated display filter");
     }
+}
+
+fn demo_status(min_level: Level, status: TraceViewStatus) -> Line<'static> {
+    let mode = match status.scroll_mode {
+        TraceScrollMode::FollowTail => "tail",
+        TraceScrollMode::Scrollback => "scrollback",
+    };
+
+    Line::from(format!(
+        "q quit | d level {min_level}+ | Up/Down scroll | End follow tail | {mode} | visible {}/{} | lost {}",
+        status.visible_events,
+        status.store.retained_events,
+        status.store.lost_events()
+    ))
 }
 
 async fn generate_traces(token: CancellationToken) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,4 +120,4 @@ pub use layer::{TraceLayer, TracingLayer};
 pub use record::{EventId, EventRecord, Level, SpanId, SpanRecord};
 pub use store::{TraceSnapshot, TraceStore, TraceStoreStatus};
 pub use timing_layer::{Timing, TimingLayer};
-pub use viewer::TraceViewer;
+pub use viewer::{TraceScrollMode, TraceViewStatus, TraceViewer};

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -11,7 +11,7 @@ use ratatui::widgets::{Paragraph, Widget};
 
 use crate::filter::TraceFilter;
 use crate::format::{event_line, FormatOptions};
-use crate::store::{TraceSnapshot, TraceStore};
+use crate::store::{TraceSnapshot, TraceStore, TraceStoreStatus};
 
 /// Event-stream trace viewer for Ratatui applications.
 ///
@@ -53,6 +53,16 @@ impl TraceViewer {
     /// Replace the display-time filter.
     pub fn set_filter(&mut self, filter: TraceFilter) {
         self.filter = filter;
+    }
+
+    /// Return structured status data for app-owned status bars.
+    ///
+    /// This clones a lightweight snapshot of retained records to count visible
+    /// events against the current display filter. It does not render or format row
+    /// text, and display-time filtering does not affect the storage counters.
+    pub fn status(&self) -> TraceViewStatus {
+        let snapshot = self.store.snapshot();
+        self.status_for_snapshot(&snapshot)
     }
 
     /// Return the active formatting options.
@@ -100,6 +110,34 @@ impl TraceViewer {
             .collect()
     }
 
+    fn visible_event_count(&self, snapshot: &TraceSnapshot) -> usize {
+        snapshot
+            .events
+            .iter()
+            .filter(|event| self.filter.matches_event(event, snapshot))
+            .count()
+    }
+
+    fn status_for_snapshot(&self, snapshot: &TraceSnapshot) -> TraceViewStatus {
+        let visible_events = self.visible_event_count(snapshot);
+        TraceViewStatus {
+            scroll_mode: if self.follow_tail {
+                TraceScrollMode::FollowTail
+            } else {
+                TraceScrollMode::Scrollback
+            },
+            scroll_top: self.scroll_top,
+            tail_scroll: self.last_tail_scroll,
+            visible_events,
+            hidden_events: snapshot
+                .status
+                .retained_events
+                .saturating_sub(visible_events),
+            filter: self.filter.clone(),
+            store: snapshot.status,
+        }
+    }
+
     fn scroll(&mut self, text_height: usize, area_height: u16) -> u16 {
         let tail_scroll = u16::try_from(text_height)
             .unwrap_or(u16::MAX)
@@ -124,4 +162,46 @@ impl Widget for &mut TraceViewer {
         let scroll = self.scroll(visible_lines, area.height);
         Paragraph::new(text).scroll((scroll, 0)).render(area, buf);
     }
+}
+
+/// Current scrolling mode for a [`TraceViewer`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TraceScrollMode {
+    /// The viewer follows the newest visible event.
+    FollowTail,
+
+    /// The user has moved into scrollback.
+    Scrollback,
+}
+
+/// Structured status summary for app-owned trace viewer chrome.
+///
+/// This type intentionally carries data, not formatted text. Applications can use
+/// it to build status bars, headers, telemetry, or tests without coupling to the
+/// library's demo wording.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TraceViewStatus {
+    /// Current scroll behavior.
+    pub scroll_mode: TraceScrollMode,
+
+    /// First visible row offset from the top of the filtered event stream.
+    pub scroll_top: u16,
+
+    /// Last computed tail offset for the filtered event stream.
+    ///
+    /// This value is updated during rendering because it depends on the render
+    /// area height. Before the first render it is zero.
+    pub tail_scroll: u16,
+
+    /// Number of retained events accepted by the active display filter.
+    pub visible_events: usize,
+
+    /// Number of retained events hidden by the active display filter.
+    pub hidden_events: usize,
+
+    /// Active display filter.
+    pub filter: TraceFilter,
+
+    /// Storage status for retained records and storage-level event loss.
+    pub store: TraceStoreStatus,
 }

--- a/tests/public_workflow.rs
+++ b/tests/public_workflow.rs
@@ -3,7 +3,7 @@ use ratatui::Terminal;
 use tracing::subscriber;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::Registry;
-use tui_tracing::{FieldValue, TraceFilter, TraceLayer, TraceStore, TraceViewer};
+use tui_tracing::{FieldValue, TraceFilter, TraceLayer, TraceScrollMode, TraceStore, TraceViewer};
 
 #[test]
 fn store_status_tracks_empty_capacity_as_dropped_events() {
@@ -201,6 +201,65 @@ fn display_filter_does_not_drop_captured_events() {
     let rendered = buffer_text(terminal.backend().buffer());
     assert!(rendered.contains("visible"));
     assert!(!rendered.contains("hidden by display filter"));
+}
+
+#[test]
+fn viewer_status_reports_follow_mode_and_visible_counts_without_rendering() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        tracing::debug!("hidden");
+        tracing::info!("visible");
+        tracing::warn!("also visible");
+    });
+
+    let mut viewer = TraceViewer::new(store);
+    viewer.set_filter(TraceFilter::all().with_min_level(tracing::Level::INFO));
+
+    let status = viewer.status();
+    assert_eq!(status.scroll_mode, TraceScrollMode::FollowTail);
+    assert_eq!(status.scroll_top, 0);
+    assert_eq!(status.tail_scroll, 0);
+    assert_eq!(status.visible_events, 2);
+    assert_eq!(status.hidden_events, 1);
+    assert_eq!(status.store.retained_events, 3);
+    assert_eq!(
+        status.filter,
+        TraceFilter::all().with_min_level(tracing::Level::INFO)
+    );
+}
+
+#[test]
+fn viewer_status_reports_scrollback_after_scroll_changes() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        for index in 0..6 {
+            tracing::info!(index, "event-{index}");
+        }
+    });
+
+    let mut viewer = TraceViewer::new(store);
+    render_viewer(&mut viewer, 100, 3);
+
+    let status = viewer.status();
+    assert_eq!(status.scroll_mode, TraceScrollMode::FollowTail);
+    assert_eq!(status.tail_scroll, 3);
+    assert_eq!(status.scroll_top, 3);
+    assert_eq!(status.visible_events, 6);
+
+    viewer.scroll_up(2);
+    let status = viewer.status();
+    assert_eq!(status.scroll_mode, TraceScrollMode::Scrollback);
+    assert_eq!(status.tail_scroll, 3);
+    assert_eq!(status.scroll_top, 1);
+
+    viewer.follow_tail();
+    let status = viewer.status();
+    assert_eq!(status.scroll_mode, TraceScrollMode::FollowTail);
+    assert_eq!(status.scroll_top, status.tail_scroll);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add `TraceViewStatus` and `TraceScrollMode` for app-owned trace viewer chrome
- expose visible/hidden event counts, scroll mode, scroll offsets, active filter, and storage status
- update the demo status bar to consume `TraceViewer::status()`
- add a VHS demo tape and `just demo-gif` workflow for generating review/release GIFs without committing binaries
- document release checklist expectations for generated demo GIF assets
- test follow mode, scrollback mode, and filtered status views

Demo GIF release asset: https://github.com/joshka/tui-tracing/releases/download/v0.1.0/tui-tracing-demo.gif

Closes #10.
Closes #30.

## Validation

- `vhs validate tapes/demo.tape`
- `just demo-gif`
- `just ci`
