### PR TITLE
Add VHS demo capture workflow

### DIFF
--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -36,6 +36,17 @@ This crate is experimental, but releases should still use a repeatable quality g
    for an actual release candidate.
 
 1. Inspect the packaged README, examples, license files, and included source files.
+1. Regenerate demo GIFs when the viewer, demo, or README screenshots change:
+
+   ```sh
+   just demo-gif
+   ```
+
+   Generated GIFs are written under `target/vhs/`, which is ignored by version control. Do not
+   commit generated GIFs. For pull request review, attach generated GIFs directly to a pull request
+   comment. Use GitHub release assets only for actual release artifacts that should become stable
+   README or docs links.
+
 1. Publish with a dry run first.
 1. For the first crates.io release, publish manually with a scoped token. crates.io requires the
    first release before trusted publishing can be configured.

--- a/justfile
+++ b/justfile
@@ -34,3 +34,7 @@ machete:
     cargo machete
 
 ci: fmt-check check test clippy doc markdown package audit machete
+
+demo-gif:
+    mkdir -p target/vhs
+    env -u NO_COLOR -u CLICOLOR -u CLICOLOR_FORCE -u FORCE_COLOR vhs tapes/demo.tape

--- a/tapes/demo.tape
+++ b/tapes/demo.tape
@@ -1,0 +1,33 @@
+Output target/vhs/tui-tracing-demo.gif
+
+Require cargo
+Require vhs
+
+Set Width 1200
+Set Height 760
+Set TypingSpeed 25ms
+Set Theme "Aardvark Blue"
+
+Hide
+Type "rm -f trace.log"
+Enter
+Wait
+Type "cargo run --example demo"
+Enter
+Sleep 4s
+Show
+Sleep 6s
+
+Type "d"
+Sleep 3s
+Type "d"
+Sleep 3s
+Up 5
+Sleep 4s
+Down 2
+Sleep 2s
+Down 10
+Sleep 4s
+Hide
+Type "q"
+Wait


### PR DESCRIPTION
## Summary

- add `tapes/demo.tape` for recording the live demo with waits on visible TUI state
- add `just demo-gif` to generate `target/vhs/tui-tracing-demo.gif`
- follow Ratatui capture guidance: Aardvark Blue, 1200px width, hidden setup, and readable dwell time for dense log output
- document that PR review GIFs should be attached directly to PR comments, while release assets are reserved for actual releases
- keep generated GIFs out of the repository under ignored `target/` output

Closes #30.

## Validation

- `vhs validate tapes/demo.tape`
- `just demo-gif`
- `just ci`
