### PR TITLE
Add trace viewer selection state

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,12 @@ still preserving correct follow-tail and scrollback behavior.
 
 Applications can call `TraceViewer::status()` to build their own status bars without duplicating
 viewer logic. The returned status includes follow-tail versus scrollback mode, the last computed
-scroll offsets, visible and hidden event counts after display filtering, the active filter, and
-the underlying `TraceStoreStatus`.
+scroll offsets, visible and hidden event counts after display filtering, selected visible row
+state, the active filter, and the underlying `TraceStoreStatus`.
+
+Selection is tracked by retained event id and interpreted through the active display filter.
+Applications can move selection with `select_next`, `select_previous`, `select_first`, and
+`select_last`, then read `selected_event` or `TraceViewer::status()` for app-owned detail views.
 
 ## Current Public Path
 
@@ -98,8 +102,8 @@ path above.
   views.
 - The timing layer remains local to this crate. The related upstream tracing PR did not appear to
   land as a stable `tracing-subscriber` API.
-- Selection, expanded details, grouped rows, page movement, and higher-level viewer status
-  summaries are planned follow-up work rather than part of the initial viewer surface.
+- Expanded details, grouped rows, page movement, and higher-level viewer status summaries are
+  planned follow-up work rather than part of the initial viewer surface.
 
 The follow-up work is tracked in the
 [main trace viewer roadmap](https://github.com/joshka/tui-tracing/issues/22).

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::time::Duration;
 
 use color_eyre::Result;
-use crossterm::event::{Event, KeyCode};
+use crossterm::event::{Event, KeyCode, KeyEvent};
 use futures::StreamExt;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
@@ -105,28 +105,17 @@ impl App {
             return Ok(());
         };
 
-        match event? {
-            Event::Key(event) if event.code == KeyCode::Char('q') => {
-                self.cancellation_token.cancel();
-            }
-            Event::Key(event) if event.code == KeyCode::Char('d') => {
-                self.cycle_level();
-            }
-            Event::Key(event) if event.code == KeyCode::Up => {
-                self.viewer.scroll_up(1);
-            }
-            Event::Key(event) if event.code == KeyCode::Down => {
-                self.viewer.scroll_down(1);
-            }
-            Event::Key(event) if event.code == KeyCode::End => {
-                self.viewer.follow_tail();
-            }
-            Event::Key(event) => {
-                debug!(?event, "ignored key");
-            }
-            event => {
-                trace!(?event, "ignored terminal event");
-            }
+        let event = event?;
+        match action_for_event(&event) {
+            Some(Action::Quit) => self.cancellation_token.cancel(),
+            Some(Action::CycleLevel) => self.cycle_level(),
+            Some(Action::SelectNext) => self.viewer.select_next(),
+            Some(Action::SelectPrevious) => self.viewer.select_previous(),
+            Some(Action::ClearSelection) => self.viewer.clear_selection(),
+            Some(Action::ScrollUp(lines)) => self.viewer.scroll_up(lines),
+            Some(Action::ScrollDown(lines)) => self.viewer.scroll_down(lines),
+            Some(Action::FollowTail) => self.viewer.follow_tail(),
+            None => log_ignored_event(event),
         }
 
         Ok(())
@@ -146,14 +135,58 @@ impl App {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Action {
+    Quit,
+    CycleLevel,
+    SelectNext,
+    SelectPrevious,
+    ClearSelection,
+    ScrollUp(u16),
+    ScrollDown(u16),
+    FollowTail,
+}
+
+fn action_for_event(event: &Event) -> Option<Action> {
+    let Event::Key(KeyEvent { code, .. }) = event else {
+        return None;
+    };
+
+    match code {
+        KeyCode::Char('q') => Some(Action::Quit),
+        KeyCode::Char('l') => Some(Action::CycleLevel),
+        KeyCode::Char('j') => Some(Action::SelectNext),
+        KeyCode::Char('k') => Some(Action::SelectPrevious),
+        KeyCode::Esc => Some(Action::ClearSelection),
+        KeyCode::Char('u') | KeyCode::Up => Some(Action::ScrollUp(1)),
+        KeyCode::Char('d') | KeyCode::Down => Some(Action::ScrollDown(1)),
+        KeyCode::Char('b') | KeyCode::PageUp => Some(Action::ScrollUp(10)),
+        KeyCode::Char('f') | KeyCode::PageDown => Some(Action::ScrollDown(10)),
+        KeyCode::Char('g') | KeyCode::Home => Some(Action::ScrollUp(u16::MAX)),
+        KeyCode::Char('G') | KeyCode::End => Some(Action::FollowTail),
+        _ => None,
+    }
+}
+
+fn log_ignored_event(event: Event) {
+    match event {
+        Event::Key(event) => debug!(?event, "ignored key"),
+        event => trace!(?event, "ignored terminal event"),
+    }
+}
+
 fn demo_status(min_level: Level, status: TraceViewStatus) -> Line<'static> {
     let mode = match status.scroll_mode {
         TraceScrollMode::FollowTail => "tail",
         TraceScrollMode::Scrollback => "scrollback",
     };
+    let selected = status
+        .selected_visible_index
+        .map(|index| format!("selected {}/{}", index + 1, status.visible_events))
+        .unwrap_or_else(|| "selected none".to_owned());
 
     Line::from(format!(
-        "q quit | d level {min_level}+ | Up/Down scroll | End follow tail | {mode} | visible {}/{} | lost {}",
+        "q quit | l level {min_level}+ | j/k select | Esc clear | Up/Down or u/d scroll | PgUp/PgDn or b/f page | g/G jump | {mode} | {selected} | visible {}/{} | lost {}",
         status.visible_events,
         status.store.retained_events,
         status.store.lost_events()

--- a/justfile
+++ b/justfile
@@ -38,3 +38,4 @@ ci: fmt-check check test clippy doc markdown package audit machete
 demo-gif:
     mkdir -p target/vhs
     env -u NO_COLOR -u CLICOLOR -u CLICOLOR_FORCE -u FORCE_COLOR vhs tapes/demo.tape
+    env -u NO_COLOR -u CLICOLOR -u CLICOLOR_FORCE -u FORCE_COLOR vhs tapes/selection.tape

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,9 +94,9 @@
 //! features built from [`TraceStore`].
 //!
 //! The current implementation is an initial version of that shape. Missing pieces
-//! that the public API should grow toward include selected-row state, detail
-//! rendering, compact filter/status summaries, overflow handling for long context
-//! and fields, grouped rows, and tests for follow-tail and selection behavior.
+//! that the public API should grow toward include detail rendering, compact
+//! filter/status summaries, overflow handling for long context and fields, and
+//! grouped rows.
 
 #![forbid(unsafe_code)]
 #![deny(rustdoc::bare_urls)]

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -6,11 +6,13 @@
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
+use ratatui::style::{Modifier, Style};
 use ratatui::text::Text;
 use ratatui::widgets::{Paragraph, Widget};
 
 use crate::filter::TraceFilter;
 use crate::format::{event_line, FormatOptions};
+use crate::record::{EventId, EventRecord};
 use crate::store::{TraceSnapshot, TraceStore, TraceStoreStatus};
 
 /// Event-stream trace viewer for Ratatui applications.
@@ -25,6 +27,7 @@ pub struct TraceViewer {
     follow_tail: bool,
     scroll_top: u16,
     last_tail_scroll: u16,
+    selected_event_id: Option<EventId>,
 }
 
 impl TraceViewer {
@@ -37,6 +40,7 @@ impl TraceViewer {
             follow_tail: true,
             scroll_top: 0,
             last_tail_scroll: 0,
+            selected_event_id: None,
         }
     }
 
@@ -53,6 +57,7 @@ impl TraceViewer {
     /// Replace the display-time filter.
     pub fn set_filter(&mut self, filter: TraceFilter) {
         self.filter = filter;
+        self.clamp_selection();
     }
 
     /// Return structured status data for app-owned status bars.
@@ -63,6 +68,48 @@ impl TraceViewer {
     pub fn status(&self) -> TraceViewStatus {
         let snapshot = self.store.snapshot();
         self.status_for_snapshot(&snapshot)
+    }
+
+    /// Return the selected retained event if it is still visible.
+    pub fn selected_event(&self) -> Option<EventRecord> {
+        let snapshot = self.store.snapshot();
+        self.selected_event_for_snapshot(&snapshot).cloned()
+    }
+
+    /// Select the first visible event if there is one.
+    pub fn select_first(&mut self) {
+        let snapshot = self.store.snapshot();
+        self.selected_event_id = self.visible_events(&snapshot).first().map(|event| event.id);
+    }
+
+    /// Select the last visible event if there is one.
+    pub fn select_last(&mut self) {
+        let snapshot = self.store.snapshot();
+        self.selected_event_id = self.visible_events(&snapshot).last().map(|event| event.id);
+    }
+
+    /// Move selection toward newer visible events.
+    ///
+    /// If no event is selected, this selects the first visible event.
+    pub fn select_next(&mut self) {
+        let snapshot = self.store.snapshot();
+        let visible_events = self.visible_events(&snapshot);
+        self.selected_event_id = next_selected_event_id(&visible_events, self.selected_event_id);
+    }
+
+    /// Move selection toward older visible events.
+    ///
+    /// If no event is selected, this selects the last visible event.
+    pub fn select_previous(&mut self) {
+        let snapshot = self.store.snapshot();
+        let visible_events = self.visible_events(&snapshot);
+        self.selected_event_id =
+            previous_selected_event_id(&visible_events, self.selected_event_id);
+    }
+
+    /// Clear the selected event.
+    pub fn clear_selection(&mut self) {
+        self.selected_event_id = None;
     }
 
     /// Return the active formatting options.
@@ -102,24 +149,62 @@ impl TraceViewer {
     }
 
     fn visible_text(&self, snapshot: &TraceSnapshot) -> Text<'static> {
-        snapshot
-            .events
-            .iter()
-            .filter(|event| self.filter.matches_event(event, snapshot))
-            .map(|event| event_line(event, snapshot, &self.format))
+        let selected_event_id = self.selected_event_id;
+        self.visible_events(snapshot)
+            .into_iter()
+            .map(|event| {
+                let line = event_line(event, snapshot, &self.format);
+                if Some(event.id) == selected_event_id {
+                    line.style(Style::default().add_modifier(Modifier::REVERSED))
+                } else {
+                    line
+                }
+            })
             .collect()
     }
 
     fn visible_event_count(&self, snapshot: &TraceSnapshot) -> usize {
+        self.visible_events(snapshot).len()
+    }
+
+    fn visible_events<'snapshot>(
+        &self,
+        snapshot: &'snapshot TraceSnapshot,
+    ) -> Vec<&'snapshot EventRecord> {
         snapshot
             .events
             .iter()
             .filter(|event| self.filter.matches_event(event, snapshot))
-            .count()
+            .collect()
+    }
+
+    fn selected_event_for_snapshot<'snapshot>(
+        &self,
+        snapshot: &'snapshot TraceSnapshot,
+    ) -> Option<&'snapshot EventRecord> {
+        let selected_event_id = self.selected_event_id?;
+        self.visible_events(snapshot)
+            .into_iter()
+            .find(|event| event.id == selected_event_id)
+    }
+
+    fn selected_visible_index(&self, snapshot: &TraceSnapshot) -> Option<usize> {
+        let selected_event_id = self.selected_event_id?;
+        self.visible_events(snapshot)
+            .into_iter()
+            .position(|event| event.id == selected_event_id)
+    }
+
+    fn clamp_selection(&mut self) {
+        if self.selected_event().is_none() {
+            self.selected_event_id = None;
+        }
     }
 
     fn status_for_snapshot(&self, snapshot: &TraceSnapshot) -> TraceViewStatus {
         let visible_events = self.visible_event_count(snapshot);
+        let selected_visible_index = self.selected_visible_index(snapshot);
+        let selected_event_id = selected_visible_index.and(self.selected_event_id);
         TraceViewStatus {
             scroll_mode: if self.follow_tail {
                 TraceScrollMode::FollowTail
@@ -133,6 +218,8 @@ impl TraceViewer {
                 .status
                 .retained_events
                 .saturating_sub(visible_events),
+            selected_visible_index,
+            selected_event_id,
             filter: self.filter.clone(),
             store: snapshot.status,
         }
@@ -152,6 +239,50 @@ impl TraceViewer {
             self.scroll_top
         }
     }
+}
+
+fn next_selected_event_id(
+    visible_events: &[&EventRecord],
+    selected_event_id: Option<EventId>,
+) -> Option<EventId> {
+    if visible_events.is_empty() {
+        return None;
+    }
+
+    let Some(selected_event_id) = selected_event_id else {
+        return Some(visible_events[0].id);
+    };
+
+    let Some(selected_index) = visible_events
+        .iter()
+        .position(|event| event.id == selected_event_id)
+    else {
+        return visible_events.first().map(|event| event.id);
+    };
+    let next_index = (selected_index + 1).min(visible_events.len() - 1);
+    Some(visible_events[next_index].id)
+}
+
+fn previous_selected_event_id(
+    visible_events: &[&EventRecord],
+    selected_event_id: Option<EventId>,
+) -> Option<EventId> {
+    if visible_events.is_empty() {
+        return None;
+    }
+
+    let Some(selected_event_id) = selected_event_id else {
+        return visible_events.last().map(|event| event.id);
+    };
+
+    let Some(selected_index) = visible_events
+        .iter()
+        .position(|event| event.id == selected_event_id)
+    else {
+        return visible_events.last().map(|event| event.id);
+    };
+    let previous_index = selected_index.saturating_sub(1);
+    Some(visible_events[previous_index].id)
 }
 
 impl Widget for &mut TraceViewer {
@@ -198,6 +329,12 @@ pub struct TraceViewStatus {
 
     /// Number of retained events hidden by the active display filter.
     pub hidden_events: usize,
+
+    /// Selected event position in the filtered visible event stream.
+    pub selected_visible_index: Option<usize>,
+
+    /// Selected event identifier, if the selected event is still visible.
+    pub selected_event_id: Option<EventId>,
 
     /// Active display filter.
     pub filter: TraceFilter,

--- a/tapes/selection.tape
+++ b/tapes/selection.tape
@@ -1,11 +1,10 @@
-Output target/vhs/tui-tracing-demo.gif
+Output target/vhs/tui-tracing-selection.gif
 
 Require cargo
 Require vhs
 
 Set Width 1200
 Set Height 760
-Set TypingSpeed 25ms
 Set Theme "Aardvark Blue"
 
 Hide
@@ -16,7 +15,7 @@ Type "cargo run --example demo"
 Enter
 Sleep 4s
 Show
-Sleep 6s
+Sleep 4s
 
 Type "j"
 Sleep 1s
@@ -27,16 +26,6 @@ Sleep 1s
 Escape
 Sleep 1s
 Type "j"
-Sleep 2s
-Type "d"
-Sleep 3s
-Type "d"
-Sleep 3s
-Up 5
-Sleep 4s
-Down 2
-Sleep 2s
-Down 10
 Sleep 4s
 Hide
 Type "q"

--- a/tests/public_workflow.rs
+++ b/tests/public_workflow.rs
@@ -263,6 +263,146 @@ fn viewer_status_reports_scrollback_after_scroll_changes() {
 }
 
 #[test]
+fn viewer_selection_is_empty_without_visible_events() {
+    let store = TraceStore::default();
+    let mut viewer = TraceViewer::new(store);
+
+    assert_eq!(viewer.status().selected_event_id, None);
+    assert!(viewer.selected_event().is_none());
+
+    viewer.select_next();
+    assert_eq!(viewer.status().selected_event_id, None);
+
+    viewer.select_previous();
+    assert_eq!(viewer.status().selected_event_id, None);
+}
+
+#[test]
+fn viewer_selection_moves_through_visible_events() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        tracing::info!("only");
+    });
+
+    let mut viewer = TraceViewer::new(store);
+
+    viewer.select_next();
+    assert_eq!(viewer.status().selected_visible_index, Some(0));
+    assert_eq!(
+        selected_message(&viewer),
+        Some(FieldValue::Debug("only".to_owned()))
+    );
+
+    viewer.select_next();
+    assert_eq!(viewer.status().selected_visible_index, Some(0));
+
+    viewer.clear_selection();
+    assert_eq!(viewer.status().selected_event_id, None);
+
+    viewer.select_previous();
+    assert_eq!(viewer.status().selected_visible_index, Some(0));
+}
+
+#[test]
+fn viewer_selection_uses_filtered_visible_rows() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        tracing::debug!("hidden");
+        tracing::info!("visible-info");
+        tracing::warn!("visible-warn");
+    });
+
+    let mut viewer = TraceViewer::new(store);
+    viewer.set_filter(TraceFilter::all().with_min_level(tracing::Level::INFO));
+
+    viewer.select_next();
+    assert_eq!(viewer.status().selected_visible_index, Some(0));
+    assert_eq!(
+        selected_message(&viewer),
+        Some(FieldValue::Debug("visible-info".to_owned()))
+    );
+
+    viewer.select_next();
+    assert_eq!(viewer.status().selected_visible_index, Some(1));
+    assert_eq!(
+        selected_message(&viewer),
+        Some(FieldValue::Debug("visible-warn".to_owned()))
+    );
+
+    viewer.set_filter(TraceFilter::all().with_min_level(tracing::Level::ERROR));
+    assert_eq!(viewer.status().selected_event_id, None);
+    assert!(viewer.selected_event().is_none());
+}
+
+#[test]
+fn viewer_selection_is_stable_when_new_events_arrive() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        for index in 0..4 {
+            tracing::info!("event-{index}");
+        }
+
+        let mut viewer = TraceViewer::new(store.clone());
+        viewer.select_next();
+        viewer.select_next();
+        viewer.select_next();
+        let selected_event_id = viewer.status().selected_event_id;
+        assert_eq!(
+            selected_message(&viewer),
+            Some(FieldValue::Debug("event-2".to_owned()))
+        );
+
+        viewer.scroll_up(1);
+
+        for index in 4..7 {
+            tracing::info!("event-{index}");
+        }
+
+        let status = viewer.status();
+        assert_eq!(status.selected_event_id, selected_event_id);
+        assert_eq!(status.selected_visible_index, Some(2));
+        assert_eq!(
+            selected_message(&viewer),
+            Some(FieldValue::Debug("event-2".to_owned()))
+        );
+    });
+}
+
+#[test]
+fn viewer_selection_clears_when_retention_evicts_selected_event() {
+    let store = TraceStore::with_capacity(2);
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        tracing::info!("one");
+        tracing::info!("two");
+
+        let mut viewer = TraceViewer::new(store.clone());
+        viewer.select_first();
+        assert_eq!(
+            selected_message(&viewer),
+            Some(FieldValue::Debug("one".to_owned()))
+        );
+
+        tracing::info!("three");
+        assert_eq!(viewer.status().selected_event_id, None);
+        assert!(viewer.selected_event().is_none());
+
+        viewer.select_next();
+        assert_eq!(
+            selected_message(&viewer),
+            Some(FieldValue::Debug("two".to_owned()))
+        );
+    });
+}
+
+#[test]
 fn viewer_follows_tail_by_default() {
     let store = TraceStore::default();
     let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
@@ -331,4 +471,10 @@ fn render_viewer(viewer: &mut TraceViewer, width: u16, height: u16) -> String {
         .draw(|frame| frame.render_widget(viewer, frame.area()))
         .unwrap();
     buffer_text(terminal.backend().buffer())
+}
+
+fn selected_message(viewer: &TraceViewer) -> Option<FieldValue> {
+    viewer
+        .selected_event()
+        .and_then(|event| event.fields.get("message").cloned())
 }


### PR DESCRIPTION
## Summary

- add visible-event selection state to `TraceViewer`, stored by retained event id
- add `select_first`, `select_last`, `select_next`, `select_previous`, `clear_selection`, and `selected_event`
- expose selected visible index and selected event id through `TraceViewStatus`
- preserve selection across appended events and clear it when filters or retention make it invisible
- render selected rows with reversed styling
- update the demo with vim-style `j`/`k` selection controls, `Esc` clear, selected-row status text, cleaner action decoding, ignored-event logging, and common scroll/page/jump keys
- document selection behavior in README and crate docs

Closes #8.

## Validation

- `cargo test --test public_workflow viewer_selection --all-features`
- `cargo test --examples --workspace --all-features`
- `just ci`
