### PR TITLE
Add viewer page movement controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ current number of visible rows. That value is only known once the host applicati
 layout area for the widget.
 
 The practical effect is that applications can keep `TraceViewer` directly in app state, mutate it
-through methods such as `set_filter`, `scroll_up`, `scroll_down`, and `follow_tail`, and then
-render `&mut viewer` in the area they assign to trace output. This avoids `StatefulWidget` while
-still preserving correct follow-tail and scrollback behavior.
+through methods such as `set_filter`, `scroll_up`, `scroll_down`, `page_up`, `page_down`,
+`jump_to_oldest`, and `jump_to_newest`, and then render `&mut viewer` in the area they assign to
+trace output. This avoids `StatefulWidget` while still preserving correct follow-tail and
+scrollback behavior.
 
 Applications can call `TraceViewer::status()` to build their own status bars without duplicating
 viewer logic. The returned status includes follow-tail versus scrollback mode, the last computed

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -112,9 +112,12 @@ impl App {
             Some(Action::SelectNext) => self.viewer.select_next(),
             Some(Action::SelectPrevious) => self.viewer.select_previous(),
             Some(Action::ClearSelection) => self.viewer.clear_selection(),
-            Some(Action::ScrollUp(lines)) => self.viewer.scroll_up(lines),
-            Some(Action::ScrollDown(lines)) => self.viewer.scroll_down(lines),
-            Some(Action::FollowTail) => self.viewer.follow_tail(),
+            Some(Action::ScrollUp) => self.viewer.scroll_up(1),
+            Some(Action::ScrollDown) => self.viewer.scroll_down(1),
+            Some(Action::PageUp) => self.viewer.page_up(),
+            Some(Action::PageDown) => self.viewer.page_down(),
+            Some(Action::JumpOldest) => self.viewer.jump_to_oldest(),
+            Some(Action::JumpNewest) => self.viewer.jump_to_newest(),
             None => log_ignored_event(event),
         }
 
@@ -142,9 +145,12 @@ enum Action {
     SelectNext,
     SelectPrevious,
     ClearSelection,
-    ScrollUp(u16),
-    ScrollDown(u16),
-    FollowTail,
+    ScrollUp,
+    ScrollDown,
+    PageUp,
+    PageDown,
+    JumpOldest,
+    JumpNewest,
 }
 
 fn action_for_event(event: &Event) -> Option<Action> {
@@ -158,12 +164,12 @@ fn action_for_event(event: &Event) -> Option<Action> {
         KeyCode::Char('j') => Some(Action::SelectNext),
         KeyCode::Char('k') => Some(Action::SelectPrevious),
         KeyCode::Esc => Some(Action::ClearSelection),
-        KeyCode::Char('u') | KeyCode::Up => Some(Action::ScrollUp(1)),
-        KeyCode::Char('d') | KeyCode::Down => Some(Action::ScrollDown(1)),
-        KeyCode::Char('b') | KeyCode::PageUp => Some(Action::ScrollUp(10)),
-        KeyCode::Char('f') | KeyCode::PageDown => Some(Action::ScrollDown(10)),
-        KeyCode::Char('g') | KeyCode::Home => Some(Action::ScrollUp(u16::MAX)),
-        KeyCode::Char('G') | KeyCode::End => Some(Action::FollowTail),
+        KeyCode::Char('u') | KeyCode::Up => Some(Action::ScrollUp),
+        KeyCode::Char('d') | KeyCode::Down => Some(Action::ScrollDown),
+        KeyCode::Char('b') | KeyCode::PageUp => Some(Action::PageUp),
+        KeyCode::Char('f') | KeyCode::PageDown => Some(Action::PageDown),
+        KeyCode::Char('g') | KeyCode::Home => Some(Action::JumpOldest),
+        KeyCode::Char('G') | KeyCode::End => Some(Action::JumpNewest),
         _ => None,
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,7 +77,8 @@
 //! - set or clear the minimum visible level;
 //! - filter by target, module, span name, text, field name, or field value;
 //! - scroll older or newer;
-//! - jump back to the newest visible event;
+//! - move by rendered pages;
+//! - jump to the oldest or newest visible event;
 //! - select previous or next visible event;
 //! - expand selected event details;
 //! - toggle source locations;

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -27,6 +27,7 @@ pub struct TraceViewer {
     follow_tail: bool,
     scroll_top: u16,
     last_tail_scroll: u16,
+    last_viewport_height: Option<u16>,
     selected_event_id: Option<EventId>,
 }
 
@@ -40,6 +41,7 @@ impl TraceViewer {
             follow_tail: true,
             scroll_top: 0,
             last_tail_scroll: 0,
+            last_viewport_height: None,
             selected_event_id: None,
         }
     }
@@ -148,6 +150,36 @@ impl TraceViewer {
         }
     }
 
+    /// Scroll one rendered page toward older visible events.
+    ///
+    /// Page size is the height of the most recent render area. Before the first
+    /// render, the viewer uses one line because no viewport height is known yet.
+    pub fn page_up(&mut self) {
+        self.scroll_up(self.page_scroll_lines());
+    }
+
+    /// Scroll one rendered page toward newer visible events.
+    ///
+    /// Page size is the height of the most recent render area. Before the first
+    /// render, the viewer uses one line because no viewport height is known yet.
+    pub fn page_down(&mut self) {
+        self.scroll_down(self.page_scroll_lines());
+    }
+
+    /// Jump to the oldest retained event accepted by the display filter.
+    pub fn jump_to_oldest(&mut self) {
+        self.follow_tail = false;
+        self.scroll_top = 0;
+    }
+
+    /// Jump to the newest retained event accepted by the display filter.
+    ///
+    /// This returns the viewer to follow-tail mode so newly retained visible events
+    /// remain pinned to the bottom of the rendered area.
+    pub fn jump_to_newest(&mut self) {
+        self.follow_tail();
+    }
+
     fn visible_text(&self, snapshot: &TraceSnapshot) -> Text<'static> {
         let selected_event_id = self.selected_event_id;
         self.visible_events(snapshot)
@@ -226,6 +258,7 @@ impl TraceViewer {
     }
 
     fn scroll(&mut self, text_height: usize, area_height: u16) -> u16 {
+        self.last_viewport_height = Some(area_height);
         let tail_scroll = u16::try_from(text_height)
             .unwrap_or(u16::MAX)
             .saturating_sub(area_height);
@@ -238,6 +271,10 @@ impl TraceViewer {
             self.scroll_top = self.scroll_top.min(tail_scroll);
             self.scroll_top
         }
+    }
+
+    fn page_scroll_lines(&self) -> u16 {
+        self.last_viewport_height.unwrap_or(1).max(1)
     }
 }
 

--- a/tests/public_workflow.rs
+++ b/tests/public_workflow.rs
@@ -455,6 +455,177 @@ fn viewer_stays_in_scrollback_until_returning_to_tail() {
     });
 }
 
+#[test]
+fn viewer_page_controls_do_not_move_when_events_fit_viewport() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        for index in 0..2 {
+            tracing::info!("event-{index}");
+        }
+    });
+
+    let mut viewer = TraceViewer::new(store);
+    assert_eq!(
+        render_viewer_event_rows(&mut viewer, 100, 3),
+        ["event-0", "event-1"]
+    );
+
+    viewer.page_up();
+    assert_eq!(
+        render_viewer_event_rows(&mut viewer, 100, 3),
+        ["event-0", "event-1"]
+    );
+
+    viewer.page_down();
+    assert_eq!(
+        render_viewer_event_rows(&mut viewer, 100, 3),
+        ["event-0", "event-1"]
+    );
+}
+
+#[test]
+fn viewer_page_controls_do_not_move_when_events_equal_viewport() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        for index in 0..3 {
+            tracing::info!("event-{index}");
+        }
+    });
+
+    let mut viewer = TraceViewer::new(store);
+    assert_eq!(
+        render_viewer_event_rows(&mut viewer, 100, 3),
+        ["event-0", "event-1", "event-2"]
+    );
+
+    viewer.page_up();
+    assert_eq!(
+        render_viewer_event_rows(&mut viewer, 100, 3),
+        ["event-0", "event-1", "event-2"]
+    );
+
+    viewer.page_down();
+    assert_eq!(
+        render_viewer_event_rows(&mut viewer, 100, 3),
+        ["event-0", "event-1", "event-2"]
+    );
+}
+
+#[test]
+fn viewer_page_controls_move_by_rendered_viewport_height() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        for index in 0..7 {
+            tracing::info!("event-{index}");
+        }
+    });
+
+    let mut viewer = TraceViewer::new(store);
+    assert_eq!(
+        render_viewer_event_rows(&mut viewer, 100, 3),
+        ["event-4", "event-5", "event-6"]
+    );
+
+    viewer.page_up();
+    assert_eq!(
+        render_viewer_event_rows(&mut viewer, 100, 3),
+        ["event-1", "event-2", "event-3"]
+    );
+
+    viewer.page_down();
+    assert_eq!(
+        render_viewer_event_rows(&mut viewer, 100, 3),
+        ["event-4", "event-5", "event-6"]
+    );
+}
+
+#[test]
+fn viewer_jump_controls_move_to_oldest_and_newest_visible_rows() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        for index in 0..7 {
+            tracing::info!("event-{index}");
+        }
+    });
+
+    let mut viewer = TraceViewer::new(store);
+    render_viewer(&mut viewer, 100, 3);
+
+    viewer.jump_to_oldest();
+    assert_eq!(
+        render_viewer_event_rows(&mut viewer, 100, 3),
+        ["event-0", "event-1", "event-2"]
+    );
+
+    viewer.jump_to_newest();
+    assert_eq!(
+        render_viewer_event_rows(&mut viewer, 100, 3),
+        ["event-4", "event-5", "event-6"]
+    );
+}
+
+#[test]
+fn viewer_page_and_jump_controls_are_sensible_before_first_render() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        for index in 0..7 {
+            tracing::info!("event-{index}");
+        }
+    });
+
+    let mut viewer = TraceViewer::new(store);
+    viewer.page_up();
+
+    let status = viewer.status();
+    assert_eq!(status.scroll_mode, TraceScrollMode::Scrollback);
+    assert_eq!(status.scroll_top, 0);
+
+    viewer.jump_to_oldest();
+    assert_eq!(
+        render_viewer_event_rows(&mut viewer, 100, 3),
+        ["event-0", "event-1", "event-2"]
+    );
+}
+
+#[test]
+fn viewer_jump_oldest_does_not_move_when_new_events_arrive() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        for index in 0..7 {
+            tracing::info!("event-{index}");
+        }
+
+        let mut viewer = TraceViewer::new(store);
+        render_viewer(&mut viewer, 100, 3);
+        viewer.jump_to_oldest();
+        assert_eq!(
+            render_viewer_event_rows(&mut viewer, 100, 3),
+            ["event-0", "event-1", "event-2"]
+        );
+
+        for index in 7..10 {
+            tracing::info!("event-{index}");
+        }
+
+        assert_eq!(
+            render_viewer_event_rows(&mut viewer, 100, 3),
+            ["event-0", "event-1", "event-2"]
+        );
+    });
+}
+
 fn buffer_text(buffer: &ratatui::buffer::Buffer) -> String {
     buffer
         .content()
@@ -471,6 +642,41 @@ fn render_viewer(viewer: &mut TraceViewer, width: u16, height: u16) -> String {
         .draw(|frame| frame.render_widget(viewer, frame.area()))
         .unwrap();
     buffer_text(terminal.backend().buffer())
+}
+
+fn render_viewer_event_rows(viewer: &mut TraceViewer, width: u16, height: u16) -> Vec<String> {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| frame.render_widget(viewer, frame.area()))
+        .unwrap();
+
+    buffer_rows(terminal.backend().buffer())
+        .into_iter()
+        .filter_map(|row| event_label(&row))
+        .collect()
+}
+
+fn buffer_rows(buffer: &ratatui::buffer::Buffer) -> Vec<String> {
+    let area = buffer.area;
+    (area.y..area.y + area.height)
+        .map(|y| {
+            (area.x..area.x + area.width)
+                .filter_map(|x| buffer.cell((x, y)).map(|cell| cell.symbol()))
+                .collect::<String>()
+                .trim_end()
+                .to_owned()
+        })
+        .collect()
+}
+
+fn event_label(row: &str) -> Option<String> {
+    let start = row.find("event-")?;
+    let label = row[start..]
+        .split_whitespace()
+        .next()
+        .expect("split_whitespace yields the matched event label");
+    Some(label.to_owned())
 }
 
 fn selected_message(viewer: &TraceViewer) -> Option<FieldValue> {


### PR DESCRIPTION
## Summary

- add TraceViewer APIs for page up/down and oldest/newest jumps
- wire the demo page and jump keys through the new library behavior
- add Ratatui buffer rendering tests for visible rows across page and jump movement

Closes #9.

## Validation

- just ci