### PR TITLE
Add selected event detail rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,18 @@ state, the active filter, and the underlying `TraceStoreStatus`.
 Selection is tracked by retained event id and interpreted through the active display filter.
 Applications can move selection with `select_next`, `select_previous`, `select_first`, and
 `select_last`, then read `selected_event` or `TraceViewer::status()` for app-owned detail views.
+For rendering full selected-event context, call `selected_detail()` and render the returned
+`TraceEventDetail` into a caller-owned pane. Compact row rendering remains fmt-like and optimized
+for scanning; detail rendering is where full fields, source location, and span-stack context live.
+`TraceEventDetail::text()` exposes the formatted detail text for applications that need their own
+scroll state, borders, titles, or layout chrome around the detail pane.
 
 ## Current Public Path
 
 - `TraceLayer`: subscriber layer for capture.
 - `TraceStore`: shared runtime buffer of retained records and storage counters.
 - `TraceViewer`: Ratatui event-stream viewer.
+- `TraceEventDetail`: renderable selected-event detail.
 - `TraceFilter`: display-time event filter.
 - `TimingLayer`: optional span busy/idle timing layer.
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -8,9 +8,9 @@ use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use ratatui::crossterm::event::EventStream;
 use ratatui::layout::{Constraint, Layout};
-use ratatui::style::{Modifier, Style};
+use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Line;
-use ratatui::widgets::Paragraph;
+use ratatui::widgets::{Block, Paragraph};
 use ratatui::DefaultTerminal;
 use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
@@ -50,6 +50,7 @@ struct App {
     viewer: TraceViewer,
     cancellation_token: CancellationToken,
     min_level: Level,
+    detail_scroll: u16,
 }
 
 impl App {
@@ -59,6 +60,7 @@ impl App {
             viewer,
             cancellation_token: CancellationToken::new(),
             min_level: Level::DEBUG,
+            detail_scroll: 0,
         }
     }
 
@@ -90,14 +92,31 @@ impl App {
         ])
         .areas(frame.area());
 
-        let title =
-            Line::from("tui-tracing demo").style(Style::default().add_modifier(Modifier::BOLD));
-        let status = demo_status(self.min_level, self.viewer.status())
-            .style(Style::default().add_modifier(Modifier::DIM));
+        let bar_style = Style::default()
+            .fg(Color::White)
+            .bg(Color::Blue)
+            .add_modifier(Modifier::BOLD);
+        let title = Line::from("tui-tracing demo").style(bar_style);
+        let status = demo_status(self.min_level, self.viewer.status()).style(bar_style);
 
-        frame.render_widget(Paragraph::new(title), title_area);
-        frame.render_widget(&mut self.viewer, trace_area);
-        frame.render_widget(Paragraph::new(status), status_area);
+        frame.render_widget(Paragraph::new(title).style(bar_style), title_area);
+        if let Some(detail) = self.viewer.selected_detail() {
+            let [trace_area, detail_area] =
+                Layout::vertical([Constraint::Percentage(58), Constraint::Percentage(42)])
+                    .areas(trace_area);
+            frame.render_widget(&mut self.viewer, trace_area);
+            let detail_block = Block::bordered()
+                .title(" selected event detail ")
+                .border_style(Style::default().fg(Color::Cyan));
+            let detail = Paragraph::new(detail.text())
+                .scroll((self.detail_scroll, 0))
+                .block(detail_block);
+            frame.render_widget(detail, detail_area);
+        } else {
+            self.detail_scroll = 0;
+            frame.render_widget(&mut self.viewer, trace_area);
+        }
+        frame.render_widget(Paragraph::new(status).style(bar_style), status_area);
     }
 
     async fn handle_event(&mut self) -> Result<()> {
@@ -109,15 +128,30 @@ impl App {
         match action_for_event(&event) {
             Some(Action::Quit) => self.cancellation_token.cancel(),
             Some(Action::CycleLevel) => self.cycle_level(),
-            Some(Action::SelectNext) => self.viewer.select_next(),
-            Some(Action::SelectPrevious) => self.viewer.select_previous(),
-            Some(Action::ClearSelection) => self.viewer.clear_selection(),
+            Some(Action::SelectNext) => {
+                self.viewer.select_next();
+                self.detail_scroll = 0;
+            }
+            Some(Action::SelectPrevious) => {
+                self.viewer.select_previous();
+                self.detail_scroll = 0;
+            }
+            Some(Action::ClearSelection) => {
+                self.viewer.clear_selection();
+                self.detail_scroll = 0;
+            }
             Some(Action::ScrollUp) => self.viewer.scroll_up(1),
             Some(Action::ScrollDown) => self.viewer.scroll_down(1),
             Some(Action::PageUp) => self.viewer.page_up(),
             Some(Action::PageDown) => self.viewer.page_down(),
             Some(Action::JumpOldest) => self.viewer.jump_to_oldest(),
             Some(Action::JumpNewest) => self.viewer.jump_to_newest(),
+            Some(Action::DetailScrollUp) => {
+                self.detail_scroll = self.detail_scroll.saturating_sub(1);
+            }
+            Some(Action::DetailScrollDown) => {
+                self.detail_scroll = self.detail_scroll.saturating_add(1);
+            }
             None => log_ignored_event(event),
         }
 
@@ -151,6 +185,8 @@ enum Action {
     PageDown,
     JumpOldest,
     JumpNewest,
+    DetailScrollUp,
+    DetailScrollDown,
 }
 
 fn action_for_event(event: &Event) -> Option<Action> {
@@ -170,6 +206,8 @@ fn action_for_event(event: &Event) -> Option<Action> {
         KeyCode::Char('f') | KeyCode::PageDown => Some(Action::PageDown),
         KeyCode::Char('g') | KeyCode::Home => Some(Action::JumpOldest),
         KeyCode::Char('G') | KeyCode::End => Some(Action::JumpNewest),
+        KeyCode::Char('[') => Some(Action::DetailScrollUp),
+        KeyCode::Char(']') => Some(Action::DetailScrollDown),
         _ => None,
     }
 }
@@ -192,7 +230,7 @@ fn demo_status(min_level: Level, status: TraceViewStatus) -> Line<'static> {
         .unwrap_or_else(|| "selected none".to_owned());
 
     Line::from(format!(
-        "q quit | l level {min_level}+ | j/k select | Esc clear | Up/Down or u/d scroll | PgUp/PgDn or b/f page | g/G jump | {mode} | {selected} | visible {}/{} | lost {}",
+        "q quit | l level {min_level}+ | j/k select | Esc clear | u/d scroll | b/f page | g/G jump | [/] detail | {mode} | {selected} | visible {}/{} | lost {}",
         status.visible_events,
         status.store.retained_events,
         status.store.lost_events()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 //!   through [`TraceStore::status`].
 //! - [`TraceFilter`] filters retained records at display time without losing data.
 //! - [`TraceViewer`] renders the event-stream view and owns scroll/filter state.
+//! - [`TraceEventDetail`] renders full detail for one selected event.
 //! - [`TimingLayer`] optionally records span busy/idle timing.
 //!
 //! Span trees, timing summaries, and aggregation are secondary views built on the
@@ -95,9 +96,8 @@
 //! features built from [`TraceStore`].
 //!
 //! The current implementation is an initial version of that shape. Missing pieces
-//! that the public API should grow toward include detail rendering, compact
-//! filter/status summaries, overflow handling for long context and fields, and
-//! grouped rows.
+//! that the public API should grow toward include compact filter/status summaries,
+//! overflow handling for long context and fields, and grouped rows.
 
 #![forbid(unsafe_code)]
 #![deny(rustdoc::bare_urls)]
@@ -121,4 +121,6 @@ pub use layer::{TraceLayer, TracingLayer};
 pub use record::{EventId, EventRecord, Level, SpanId, SpanRecord};
 pub use store::{TraceSnapshot, TraceStore, TraceStoreStatus};
 pub use timing_layer::{Timing, TimingLayer};
-pub use viewer::{TraceScrollMode, TraceViewStatus, TraceViewer};
+pub use viewer::{
+    TraceEventDetail, TraceScrollMode, TraceSpanDetail, TraceViewStatus, TraceViewer,
+};

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -6,13 +6,14 @@
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
-use ratatui::style::{Modifier, Style};
-use ratatui::text::Text;
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span, Text};
 use ratatui::widgets::{Paragraph, Widget};
 
+use crate::field::FieldMap;
 use crate::filter::TraceFilter;
 use crate::format::{event_line, FormatOptions};
-use crate::record::{EventId, EventRecord};
+use crate::record::{EventId, EventRecord, SpanId, SpanRecord};
 use crate::store::{TraceSnapshot, TraceStore, TraceStoreStatus};
 
 /// Event-stream trace viewer for Ratatui applications.
@@ -76,6 +77,18 @@ impl TraceViewer {
     pub fn selected_event(&self) -> Option<EventRecord> {
         let snapshot = self.store.snapshot();
         self.selected_event_for_snapshot(&snapshot).cloned()
+    }
+
+    /// Return renderable detail for the selected retained event.
+    ///
+    /// The returned value owns cloned record data from a single store snapshot, so
+    /// callers can render it later without holding store locks. It returns `None`
+    /// when no event is selected or when the selected event is no longer visible
+    /// through the active display filter.
+    pub fn selected_detail(&self) -> Option<TraceEventDetail> {
+        let snapshot = self.store.snapshot();
+        let event = self.selected_event_for_snapshot(&snapshot)?;
+        Some(TraceEventDetail::from_snapshot(event, &snapshot))
     }
 
     /// Select the first visible event if there is one.
@@ -330,6 +343,258 @@ impl Widget for &mut TraceViewer {
         let scroll = self.scroll(visible_lines, area.height);
         Paragraph::new(text).scroll((scroll, 0)).render(area, buf);
     }
+}
+
+/// Renderable detail for one captured tracing event.
+///
+/// A detail value is an owned snapshot of the selected event and its span stack.
+/// It is separate from compact row rendering so applications can choose whether to
+/// show details in a bottom pane, side pane, popup, or another app-owned surface.
+#[derive(Clone, Debug)]
+pub struct TraceEventDetail {
+    event: EventRecord,
+    span_stack: Vec<TraceSpanDetail>,
+}
+
+impl TraceEventDetail {
+    /// Create event detail from an event and already-resolved span stack.
+    pub fn new(event: EventRecord, span_stack: Vec<TraceSpanDetail>) -> Self {
+        Self { event, span_stack }
+    }
+
+    /// Return the event described by this detail.
+    pub fn event(&self) -> &EventRecord {
+        &self.event
+    }
+
+    /// Return the event span stack from root to innermost span.
+    pub fn span_stack(&self) -> &[TraceSpanDetail] {
+        &self.span_stack
+    }
+
+    fn from_snapshot(event: &EventRecord, snapshot: &TraceSnapshot) -> Self {
+        let span_stack = event
+            .span_stack
+            .iter()
+            .map(|span_id| {
+                snapshot
+                    .spans
+                    .get(span_id)
+                    .cloned()
+                    .map(TraceSpanDetail::present)
+                    .unwrap_or_else(|| TraceSpanDetail::missing(*span_id))
+            })
+            .collect();
+        Self::new(event.clone(), span_stack)
+    }
+
+    /// Format this detail as Ratatui text.
+    ///
+    /// This is useful when callers need app-owned chrome or scrolling around the
+    /// library's detail content. Rendering `&TraceEventDetail` directly uses the
+    /// same text without applying any scroll offset.
+    pub fn text(&self) -> Text<'static> {
+        let mut lines = vec![
+            heading("Event"),
+            detail_line("time", self.event.timestamp.to_rfc3339()),
+            detail_line("level", self.event.level.0.to_string()),
+            detail_line("target", self.event.target.clone()),
+            metadata_line("  module", self.event.module_path.as_deref()),
+            location_line("  location", self.event.file.as_deref(), self.event.line),
+            detail_line(
+                "message",
+                self.event
+                    .fields
+                    .get("message")
+                    .map(ToString::to_string)
+                    .unwrap_or_else(|| "<none>".to_owned()),
+            ),
+        ];
+
+        push_fields(&mut lines, "Fields", &self.event.fields);
+        push_span_stack(&mut lines, &self.span_stack);
+
+        lines.into()
+    }
+}
+
+impl Widget for &TraceEventDetail {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        Paragraph::new(self.text()).render(area, buf);
+    }
+}
+
+/// Span detail for an event span stack.
+///
+/// A span detail always keeps the referenced span id. The full span record is
+/// present when it was retained in the same snapshot as the event.
+#[derive(Clone, Debug)]
+pub struct TraceSpanDetail {
+    id: SpanId,
+    record: Option<Box<SpanRecord>>,
+}
+
+impl TraceSpanDetail {
+    /// Create detail for a retained span record.
+    pub fn present(record: SpanRecord) -> Self {
+        Self {
+            id: record.id,
+            record: Some(Box::new(record)),
+        }
+    }
+
+    /// Create detail for a span id whose span record is not available.
+    pub fn missing(id: SpanId) -> Self {
+        Self { id, record: None }
+    }
+
+    /// Return the span id referenced by the event.
+    pub fn id(&self) -> SpanId {
+        self.id
+    }
+
+    /// Return the retained span record, if it is available.
+    pub fn record(&self) -> Option<&SpanRecord> {
+        self.record.as_deref()
+    }
+}
+
+fn push_fields(lines: &mut Vec<Line<'static>>, heading: &'static str, fields: &FieldMap) {
+    lines.push(heading_line(heading));
+    if fields.is_empty() {
+        lines.push(muted_line("  <none>"));
+        return;
+    }
+
+    for (name, value) in fields {
+        lines.push(detail_line(name, value.to_string()));
+    }
+}
+
+fn push_span_stack(lines: &mut Vec<Line<'static>>, span_stack: &[TraceSpanDetail]) {
+    lines.push(heading("Span stack"));
+    if span_stack.is_empty() {
+        lines.push(muted_line("  <none>"));
+        return;
+    }
+
+    for (index, detail) in span_stack.iter().enumerate() {
+        if let Some(span) = detail.record() {
+            push_span(lines, index, span);
+        } else {
+            lines.push(muted_line(format!(
+                "  {index}. <missing span {}>",
+                detail.id()
+            )));
+        }
+    }
+}
+
+fn push_span(lines: &mut Vec<Line<'static>>, index: usize, span: &SpanRecord) {
+    lines.push(Line::from(vec![
+        Span::styled(
+            format!("  {index}. "),
+            Style::default().add_modifier(Modifier::DIM),
+        ),
+        Span::styled(
+            span.name.clone(),
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        ),
+    ]));
+    lines.push(indented_detail_line("id", span.id.to_string()));
+    lines.push(indented_detail_line("level", span.level.0.to_string()));
+    lines.push(indented_detail_line("target", span.target.clone()));
+    lines.push(metadata_line("     module", span.module_path.as_deref()));
+    lines.push(location_line(
+        "     location",
+        span.file.as_deref(),
+        span.line,
+    ));
+    lines.push(indented_detail_line(
+        "lifecycle",
+        if span.close_time.is_some() {
+            "closed"
+        } else {
+            "open"
+        },
+    ));
+    push_fields(lines, "     fields", &span.fields);
+
+    if let Some(timing) = span.timing {
+        lines.push(indented_detail_line(
+            "timing",
+            format!(
+                "state={:?} busy={:?} idle={:?} total={:?} enters={} exits={}",
+                timing.state(),
+                timing.busy_duration(),
+                timing.idle_duration(),
+                timing.total_duration(),
+                timing.enter_count(),
+                timing.exit_count()
+            ),
+        ));
+    }
+}
+
+fn heading(label: &'static str) -> Line<'static> {
+    Line::from(label).style(
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    )
+}
+
+fn heading_line(label: &'static str) -> Line<'static> {
+    Line::from(label).style(Style::default().fg(Color::Yellow))
+}
+
+fn detail_line(label: impl Into<String>, value: impl Into<String>) -> Line<'static> {
+    field_line("  ", label, value)
+}
+
+fn indented_detail_line(label: impl Into<String>, value: impl Into<String>) -> Line<'static> {
+    field_line("     ", label, value)
+}
+
+fn field_line(
+    prefix: &'static str,
+    label: impl Into<String>,
+    value: impl Into<String>,
+) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("{prefix}{}:", label.into()),
+            Style::default().fg(Color::Blue),
+        ),
+        Span::raw(" "),
+        Span::raw(value.into()),
+    ])
+}
+
+fn muted_line(text: impl Into<String>) -> Line<'static> {
+    Line::from(text.into()).style(Style::default().add_modifier(Modifier::DIM))
+}
+
+fn metadata_line(label: &'static str, value: Option<&str>) -> Line<'static> {
+    labeled_line(label, value.unwrap_or("<unknown>").to_owned())
+}
+
+fn location_line(label: &'static str, file: Option<&str>, line: Option<u32>) -> Line<'static> {
+    let value = match (file, line) {
+        (Some(file), Some(line)) => format!("{file}:{line}"),
+        (Some(file), None) => file.to_owned(),
+        (None, Some(line)) => format!("<unknown>:{line}"),
+        (None, None) => "<unknown>".to_owned(),
+    };
+    labeled_line(label, value)
+}
+
+fn labeled_line(label: &'static str, value: impl Into<String>) -> Line<'static> {
+    let prefix_len = label.len() - label.trim_start().len();
+    let (prefix, label) = label.split_at(prefix_len);
+    field_line(prefix, label, value)
 }
 
 /// Current scrolling mode for a [`TraceViewer`].

--- a/tapes/demo.tape
+++ b/tapes/demo.tape
@@ -4,7 +4,7 @@ Require cargo
 Require vhs
 
 Set Width 1200
-Set Height 760
+Set Height 1024
 Set TypingSpeed 25ms
 Set Theme "Aardvark Blue"
 
@@ -27,6 +27,10 @@ Sleep 1s
 Escape
 Sleep 1s
 Type "j"
+Sleep 2s
+Type "]"
+Sleep 1s
+Type "]"
 Sleep 2s
 Type "d"
 Sleep 3s

--- a/tapes/selection.tape
+++ b/tapes/selection.tape
@@ -4,7 +4,7 @@ Require cargo
 Require vhs
 
 Set Width 1200
-Set Height 760
+Set Height 1024
 Set Theme "Aardvark Blue"
 
 Hide
@@ -26,7 +26,11 @@ Sleep 1s
 Escape
 Sleep 1s
 Type "j"
-Sleep 4s
+Sleep 2s
+Type "]"
+Sleep 1s
+Type "]"
+Sleep 3s
 Hide
 Type "q"
 Wait

--- a/tests/public_workflow.rs
+++ b/tests/public_workflow.rs
@@ -3,7 +3,10 @@ use ratatui::Terminal;
 use tracing::subscriber;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::Registry;
-use tui_tracing::{FieldValue, TraceFilter, TraceLayer, TraceScrollMode, TraceStore, TraceViewer};
+use tui_tracing::{
+    EventRecord, FieldMap, FieldValue, Level, TraceEventDetail, TraceFilter, TraceLayer,
+    TraceScrollMode, TraceSpanDetail, TraceStore, TraceViewer,
+};
 
 #[test]
 fn store_status_tracks_empty_capacity_as_dropped_events() {
@@ -403,6 +406,100 @@ fn viewer_selection_clears_when_retention_evicts_selected_event() {
 }
 
 #[test]
+fn selected_detail_renders_event_fields_span_fields_and_source_location() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        let span = tracing::info_span!("request", user = "alice", route = "/checkout");
+        let _guard = span.enter();
+        tracing::warn!(answer = 42, "payment declined");
+    });
+
+    let mut viewer = TraceViewer::new(store);
+    viewer.select_first();
+
+    let rendered = render_detail(
+        &viewer
+            .selected_detail()
+            .expect("selected visible event has renderable detail"),
+        120,
+        24,
+    );
+
+    assert!(rendered.contains("Event"));
+    assert!(rendered.contains("level: WARN"));
+    assert!(rendered.contains("target: public_workflow"));
+    assert!(rendered.contains("location: tests/public_workflow.rs:"));
+    assert!(rendered.contains("message: payment declined"));
+    assert!(rendered.contains("answer: 42"));
+    assert!(rendered.contains("Span stack"));
+    assert!(rendered.contains("0. request"));
+    assert!(rendered.contains("user: alice"));
+    assert!(rendered.contains("route: /checkout"));
+    assert!(rendered.contains("lifecycle: closed"));
+}
+
+#[test]
+fn selected_detail_renders_field_only_events() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        tracing::info!(answer = 42, ready = true);
+    });
+
+    let mut viewer = TraceViewer::new(store);
+    viewer.select_first();
+
+    let rendered = render_detail(
+        &viewer
+            .selected_detail()
+            .expect("field-only selected event has detail"),
+        100,
+        14,
+    );
+
+    assert!(rendered.contains("message: <none>"));
+    assert!(rendered.contains("answer: 42"));
+    assert!(rendered.contains("ready: true"));
+    assert!(rendered.contains("Span stack"));
+    assert!(rendered.contains("<none>"));
+}
+
+#[test]
+fn event_detail_renders_missing_source_location_and_missing_span_records() {
+    let mut fields = FieldMap::default();
+    fields.insert(
+        "message".to_owned(),
+        FieldValue::Debug("synthetic".to_owned()),
+    );
+    fields.insert("code".to_owned(), FieldValue::U64(503));
+
+    let event = EventRecord {
+        id: 7,
+        timestamp: chrono::Local::now(),
+        level: Level(tracing::Level::ERROR),
+        target: "synthetic::target".to_owned(),
+        module_path: None,
+        file: None,
+        line: None,
+        fields,
+        span_id: Some(99),
+        span_stack: vec![99],
+    };
+    let detail = TraceEventDetail::new(event, vec![TraceSpanDetail::missing(99)]);
+
+    let rendered = render_detail(&detail, 100, 16);
+
+    assert!(rendered.contains("module: <unknown>"));
+    assert!(rendered.contains("location: <unknown>"));
+    assert!(rendered.contains("message: synthetic"));
+    assert!(rendered.contains("code: 503"));
+    assert!(rendered.contains("<missing span 99>"));
+}
+
+#[test]
 fn viewer_follows_tail_by_default() {
     let store = TraceStore::default();
     let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
@@ -655,6 +752,15 @@ fn render_viewer_event_rows(viewer: &mut TraceViewer, width: u16, height: u16) -
         .into_iter()
         .filter_map(|row| event_label(&row))
         .collect()
+}
+
+fn render_detail(detail: &TraceEventDetail, width: u16, height: u16) -> String {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).unwrap();
+    terminal
+        .draw(|frame| frame.render_widget(detail, frame.area()))
+        .unwrap();
+    buffer_rows(terminal.backend().buffer()).join("\n")
 }
 
 fn buffer_rows(buffer: &ratatui::buffer::Buffer) -> Vec<String> {


### PR DESCRIPTION
## Summary

- add TraceViewer::selected_detail() and reusable TraceEventDetail rendering
- include event metadata, fields, source location, span stack, lifecycle, and timing when available
- render selected details in the demo and document compact rows versus detail panes
- add Ratatui buffer tests for fields, spans, source locations, field-only events, and missing records

Closes #11.

## Validation

- just ci