### PR TITLE
Define formatting hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,15 @@ The default viewer is event-stream-first. It should feel familiar to users of
 `tracing_subscriber::fmt`: colored levels, readable timestamps, messages, structured fields, and
 compact span context.
 
+Compact rows default to a short local timestamp so they fit inside an application pane:
+
+```text
+12:04:31.123 INFO  app::net: request{peer="alpha"}: connected latency_ms=12
+```
+
+Selected-event detail keeps the complete timestamp, target, module path, source location, promoted
+message, event fields, span stack, span fields, lifecycle state, and timing data.
+
 Span trees, timing summaries, and aggregation are secondary views built from the same retained
 records. Nesting is important data, but it should not dominate the first diagnostic view.
 
@@ -86,9 +95,11 @@ Applications can move selection with `select_next`, `select_previous`, `select_f
 `select_last`, then read `selected_event` or `TraceViewer::status()` for app-owned detail views.
 For rendering full selected-event context, call `selected_detail()` and render the returned
 `TraceEventDetail` into a caller-owned pane. Compact row rendering remains fmt-like and optimized
-for scanning; detail rendering is where full fields, source location, and span-stack context live.
-`TraceEventDetail::text()` exposes the formatted detail text for applications that need their own
-scroll state, borders, titles, or layout chrome around the detail pane.
+for scanning: short timestamp, level, target, span context, message, and fields.
+`FormatOptions` can switch compact rows to full RFC 3339 timestamps or a custom Chrono format.
+Detail rendering is where full fields, source location, and span-stack context live.
+`TraceEventDetail::text()` exposes the formatted detail text for applications that need their
+own scroll state, borders, titles, or layout chrome around the detail pane.
 
 ## Current Public Path
 
@@ -97,6 +108,7 @@ scroll state, borders, titles, or layout chrome around the detail pane.
 - `TraceViewer`: Ratatui event-stream viewer.
 - `TraceEventDetail`: renderable selected-event detail.
 - `TraceFilter`: display-time event filter.
+- `FormatOptions`: compact row formatting options.
 - `TimingLayer`: optional span busy/idle timing layer.
 
 The demo in `examples/demo.rs` is intentionally small and should stay aligned with the public API

--- a/src/format.rs
+++ b/src/format.rs
@@ -15,13 +15,13 @@ use crate::store::TraceSnapshot;
 /// Options for rendering captured trace records.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FormatOptions {
-    /// Timestamp format used for each event line.
-    pub timestamp_format: String,
+    /// Timestamp format used for each compact event row.
+    pub timestamp_format: TimestampFormat,
 
-    /// Whether to render compact span context before the event message.
+    /// Whether to render compact span context after the event target.
     pub show_span_context: bool,
 
-    /// Whether to render event target when no span context is available.
+    /// Whether to render event target before the event message.
     pub show_target: bool,
 
     /// Whether to render source file and line when present.
@@ -31,10 +31,40 @@ pub struct FormatOptions {
 impl Default for FormatOptions {
     fn default() -> Self {
         Self {
-            timestamp_format: "%Y-%m-%dT%H:%M:%S%.6f%:z".to_owned(),
+            timestamp_format: TimestampFormat::default(),
             show_span_context: true,
             show_target: true,
             show_location: false,
+        }
+    }
+}
+
+/// Timestamp format used for compact event rows.
+///
+/// Selected-event detail always uses a full RFC 3339 timestamp. This type only
+/// controls the dense event stream where horizontal space is limited.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub enum TimestampFormat {
+    /// Local wall-clock time with millisecond precision, such as `12:04:31.123`.
+    #[default]
+    ShortLocal,
+
+    /// Full RFC 3339 timestamp with microsecond precision and local offset.
+    Rfc3339,
+
+    /// Custom [`chrono`] format string.
+    ///
+    /// Invalid format strings do not fail rendering; they are rendered according
+    /// to `chrono`'s formatting behavior.
+    Custom(String),
+}
+
+impl TimestampFormat {
+    fn format(&self, timestamp: chrono::DateTime<chrono::Local>) -> String {
+        match self {
+            Self::ShortLocal => timestamp.format("%H:%M:%S%.3f").to_string(),
+            Self::Rfc3339 => timestamp.format("%Y-%m-%dT%H:%M:%S%.6f%:z").to_string(),
+            Self::Custom(format) => timestamp.format(format).to_string(),
         }
     }
 }
@@ -46,18 +76,15 @@ pub(crate) fn event_line(
 ) -> Line<'static> {
     let mut spans = vec![
         Span::styled(
-            event
-                .timestamp
-                .format(&options.timestamp_format)
-                .to_string(),
+            options.timestamp_format.format(event.timestamp),
             Style::default().add_modifier(Modifier::DIM),
         ),
         Span::raw(" "),
         level_span(event.level),
     ];
 
-    push_context(&mut spans, event, snapshot, options);
     push_target(&mut spans, event, options);
+    push_context(&mut spans, event, snapshot, options);
 
     if options.show_location {
         push_location(&mut spans, event);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@
 //! - [`TraceStore`] retains those records for runtime inspection and exposes storage counters
 //!   through [`TraceStore::status`].
 //! - [`TraceFilter`] filters retained records at display time without losing data.
+//! - [`FormatOptions`] controls compact event-row formatting.
 //! - [`TraceViewer`] renders the event-stream view and owns scroll/filter state.
 //! - [`TraceEventDetail`] renders full detail for one selected event.
 //! - [`TimingLayer`] optionally records span busy/idle timing.
@@ -64,13 +65,18 @@
 //!
 //! ```text
 //! 12:04:31.123 INFO  app::net: connected peer=alpha latency=12ms
-//! 12:04:32.018 WARN  sync{peer=alpha}: retrying attempt=2 error=timeout
+//! 12:04:32.018 WARN  app::sync: sync{peer=alpha}: retrying attempt=2 error=timeout
 //! ```
 //!
-//! A row should remain useful when an event has no `message` field. Field-only
-//! events are valid tracing output. Complete fields, source location, full span
-//! stack, span fields, lifecycle state, and timing belong in a detail view for the
-//! selected event.
+//! Compact rows use [`TimestampFormat::ShortLocal`] by default because full
+//! timestamps are usually too wide for an in-app diagnostics pane. Rows still keep
+//! the `tracing_subscriber::fmt`-style hierarchy of level, target, span context,
+//! message, and fields. A row should remain useful when an event has no `message`
+//! field because field-only events are valid tracing output.
+//!
+//! Selected-event detail is the full metadata surface. It keeps the complete
+//! timestamp, level, target, module path, source location, promoted message, event
+//! fields, full span stack, span fields, lifecycle state, and timing.
 //!
 //! The main screen should expose behavior that applications can bind to their own
 //! input model:
@@ -116,7 +122,7 @@ mod timing_layer;
 
 pub use field::{FieldMap, FieldValue};
 pub use filter::TraceFilter;
-pub use format::FormatOptions;
+pub use format::{FormatOptions, TimestampFormat};
 pub use layer::{TraceLayer, TracingLayer};
 pub use record::{EventId, EventRecord, Level, SpanId, SpanRecord};
 pub use store::{TraceSnapshot, TraceStore, TraceStoreStatus};

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -411,7 +411,7 @@ impl TraceEventDetail {
             ),
         ];
 
-        push_fields(&mut lines, "Fields", &self.event.fields);
+        push_event_fields(&mut lines, &self.event.fields);
         push_span_stack(&mut lines, &self.span_stack);
 
         lines.into()
@@ -471,6 +471,22 @@ fn push_fields(lines: &mut Vec<Line<'static>>, heading: &'static str, fields: &F
     }
 }
 
+fn push_event_fields(lines: &mut Vec<Line<'static>>, fields: &FieldMap) {
+    lines.push(heading_line("Fields"));
+    let mut pushed = false;
+    for (name, value) in fields {
+        if name == "message" {
+            continue;
+        }
+        lines.push(detail_line(name, value.to_string()));
+        pushed = true;
+    }
+
+    if !pushed {
+        lines.push(muted_line("  <none>"));
+    }
+}
+
 fn push_span_stack(lines: &mut Vec<Line<'static>>, span_stack: &[TraceSpanDetail]) {
     lines.push(heading("Span stack"));
     if span_stack.is_empty() {
@@ -520,7 +536,6 @@ fn push_span(lines: &mut Vec<Line<'static>>, index: usize, span: &SpanRecord) {
             "open"
         },
     ));
-    push_fields(lines, "     fields", &span.fields);
 
     if let Some(timing) = span.timing {
         lines.push(indented_detail_line(
@@ -536,6 +551,7 @@ fn push_span(lines: &mut Vec<Line<'static>>, index: usize, span: &SpanRecord) {
             ),
         ));
     }
+    push_fields(lines, "     fields", &span.fields);
 }
 
 fn heading(label: &'static str) -> Line<'static> {

--- a/tests/public_workflow.rs
+++ b/tests/public_workflow.rs
@@ -4,8 +4,8 @@ use tracing::subscriber;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::Registry;
 use tui_tracing::{
-    EventRecord, FieldMap, FieldValue, Level, TraceEventDetail, TraceFilter, TraceLayer,
-    TraceScrollMode, TraceSpanDetail, TraceStore, TraceViewer,
+    EventRecord, FieldMap, FieldValue, Level, TimestampFormat, TraceEventDetail, TraceFilter,
+    TraceLayer, TraceScrollMode, TraceSpanDetail, TraceStore, TraceViewer,
 };
 
 #[test]
@@ -172,12 +172,60 @@ fn viewer_uses_default_fmt_style_ordering() {
         tracing::info!(answer = 42, "connected");
     });
 
+    let expected_timestamp = store.snapshot().events[0]
+        .timestamp
+        .format("%H:%M:%S%.3f")
+        .to_string();
     let mut viewer = TraceViewer::new(store);
     let rendered = render_viewer(&mut viewer, 140, 3);
+    let row = first_non_empty_row(&rendered);
 
-    assert!(rendered.contains("INFO  request{user=\"alice\"}:"));
-    assert!(rendered.contains("public_workflow"));
-    assert!(rendered.contains(": connected answer=42"));
+    assert!(row.starts_with(&expected_timestamp));
+    assert!(row.contains("INFO  public_workflow: request{user=\"alice\"}:"));
+    assert!(row.contains(": connected answer=42"));
+    assert_ordered(
+        row,
+        &[
+            "INFO",
+            "public_workflow:",
+            "request{user=\"alice\"}:",
+            "connected",
+            "answer=42",
+        ],
+    );
+}
+
+#[test]
+fn viewer_supports_configured_timestamp_formats() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        tracing::info!("configured timestamp");
+    });
+
+    let event = store.snapshot().events[0].clone();
+
+    let mut viewer = TraceViewer::new(store.clone());
+    let mut format = viewer.format_options().clone();
+    format.timestamp_format = TimestampFormat::Rfc3339;
+    viewer.set_format_options(format);
+    let rendered = render_viewer(&mut viewer, 140, 3);
+    assert!(first_non_empty_row(&rendered).starts_with(
+        &event
+            .timestamp
+            .format("%Y-%m-%dT%H:%M:%S%.6f%:z")
+            .to_string()
+    ));
+
+    let mut viewer = TraceViewer::new(store);
+    let mut format = viewer.format_options().clone();
+    format.timestamp_format = TimestampFormat::Custom("[%H:%M]".to_owned());
+    viewer.set_format_options(format);
+    let rendered = render_viewer(&mut viewer, 140, 3);
+    assert!(
+        first_non_empty_row(&rendered).starts_with(&event.timestamp.format("[%H:%M]").to_string())
+    );
 }
 
 #[test]
@@ -438,6 +486,26 @@ fn selected_detail_renders_event_fields_span_fields_and_source_location() {
     assert!(rendered.contains("user: alice"));
     assert!(rendered.contains("route: /checkout"));
     assert!(rendered.contains("lifecycle: closed"));
+    assert_eq!(rendered.matches("message: payment declined").count(), 1);
+    assert_ordered(
+        &rendered,
+        &[
+            "Event",
+            "time:",
+            "level:",
+            "target:",
+            "module:",
+            "location:",
+            "message:",
+            "Fields",
+            "answer:",
+            "Span stack",
+            "0. request",
+            "lifecycle:",
+            "fields",
+            "user:",
+        ],
+    );
 }
 
 #[test]
@@ -761,6 +829,23 @@ fn render_detail(detail: &TraceEventDetail, width: u16, height: u16) -> String {
         .draw(|frame| frame.render_widget(detail, frame.area()))
         .unwrap();
     buffer_rows(terminal.backend().buffer()).join("\n")
+}
+
+fn first_non_empty_row(rendered: &str) -> &str {
+    rendered
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .expect("rendered output contains a non-empty row")
+}
+
+fn assert_ordered(rendered: &str, needles: &[&str]) {
+    let mut start = 0;
+    for needle in needles {
+        let offset = rendered[start..]
+            .find(needle)
+            .unwrap_or_else(|| panic!("expected {needle:?} after byte {start} in:\n{rendered}"));
+        start += offset + needle.len();
+    }
 }
 
 fn buffer_rows(buffer: &ratatui::buffer::Buffer) -> Vec<String> {


### PR DESCRIPTION
## Summary

- add named timestamp formatting options for compact rows
- make compact event rows follow fmt-like target/span/message ordering
- promote selected detail message and document compact-vs-detail hierarchy

Closes #37.

## Validation

- just ci
- just demo-gif