### PR TITLE
Add compact row overflow indicators

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Compact rows default to a short local timestamp so they fit inside an applicatio
 12:04:31.123 INFO  app::net: request{peer="alpha"}: connected latency_ms=12
 ```
 
+When target, span context, message, or fields exceed the rendered width, compact rows use `...`
+to mark overflow. Span context truncates from the left so the innermost span remains visible when
+possible. The selected-event detail remains complete.
+
 Selected-event detail keeps the complete timestamp, target, module path, source location, promoted
 message, event fields, span stack, span fields, lifecycle state, and timing data.
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -12,6 +12,8 @@ use crate::field::{FieldMap, FieldValue};
 use crate::record::{EventRecord, Level, SpanRecord};
 use crate::store::TraceSnapshot;
 
+const OVERFLOW_MARKER: &str = "...";
+
 /// Options for rendering captured trace records.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FormatOptions {
@@ -73,75 +75,196 @@ pub(crate) fn event_line(
     event: &EventRecord,
     snapshot: &TraceSnapshot,
     options: &FormatOptions,
+    max_width: u16,
 ) -> Line<'static> {
-    let mut spans = vec![
-        Span::styled(
-            options.timestamp_format.format(event.timestamp),
-            Style::default().add_modifier(Modifier::DIM),
-        ),
-        Span::raw(" "),
-        level_span(event.level),
-    ];
+    let mut pieces = row_pieces(event, snapshot, options);
+    fit_pieces(&mut pieces, usize::from(max_width));
 
-    push_target(&mut spans, event, options);
-    push_context(&mut spans, event, snapshot, options);
-
-    if options.show_location {
-        push_location(&mut spans, event);
+    let mut spans = Vec::with_capacity(pieces.len());
+    for piece in pieces {
+        spans.push(Span::styled(piece.text, piece.style));
     }
-
-    push_message_and_fields(&mut spans, event);
-
     Line::from(spans)
 }
 
-fn push_context(
-    spans: &mut Vec<Span<'static>>,
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum RowPieceKind {
+    Fixed,
+    Target,
+    Context,
+    Location,
+    Fields,
+}
+
+struct RowPiece {
+    text: String,
+    style: Style,
+    kind: RowPieceKind,
+}
+
+impl RowPiece {
+    fn raw(text: impl Into<String>, kind: RowPieceKind) -> Self {
+        Self {
+            text: text.into(),
+            style: Style::default(),
+            kind,
+        }
+    }
+
+    fn styled(text: impl Into<String>, style: Style, kind: RowPieceKind) -> Self {
+        Self {
+            text: text.into(),
+            style,
+            kind,
+        }
+    }
+}
+
+fn row_pieces(
     event: &EventRecord,
     snapshot: &TraceSnapshot,
     options: &FormatOptions,
-) {
-    if options.show_span_context && !event.span_stack.is_empty() {
-        let mut pushed = false;
-        for span in event
+) -> Vec<RowPiece> {
+    let mut pieces = vec![
+        RowPiece::styled(
+            options.timestamp_format.format(event.timestamp),
+            Style::default().add_modifier(Modifier::DIM),
+            RowPieceKind::Fixed,
+        ),
+        RowPiece::raw(" ", RowPieceKind::Fixed),
+        RowPiece::styled(
+            level_text(event.level),
+            level_style(event.level),
+            RowPieceKind::Fixed,
+        ),
+    ];
+
+    if options.show_target {
+        pieces.push(RowPiece::styled(
+            format!("{}: ", event.target),
+            Style::default().add_modifier(Modifier::DIM),
+            RowPieceKind::Target,
+        ));
+    }
+
+    if options.show_span_context {
+        let context = event
             .span_stack
             .iter()
             .filter_map(|span_id| snapshot.spans.get(span_id))
-        {
-            spans.push(Span::styled(
-                format_span_context(span),
+            .map(format_span_context)
+            .join(": ");
+        if !context.is_empty() {
+            pieces.push(RowPiece::styled(
+                format!("{context}: "),
                 Style::default().add_modifier(Modifier::BOLD),
+                RowPieceKind::Context,
             ));
-            spans.push(Span::styled(
-                ":",
+        }
+    }
+
+    if options.show_location {
+        if let Some(location) = format_location(event) {
+            pieces.push(RowPiece::styled(
+                location,
                 Style::default().add_modifier(Modifier::DIM),
+                RowPieceKind::Location,
             ));
-            pushed = true;
         }
+    }
 
-        if pushed {
-            spans.push(Span::raw(" "));
+    let fields = format_event_fields(&event.fields);
+    if !fields.is_empty() {
+        pieces.push(RowPiece::raw(fields, RowPieceKind::Fields));
+    }
+
+    pieces
+}
+
+fn fit_pieces(pieces: &mut [RowPiece], max_width: usize) {
+    if max_width == 0 {
+        for piece in pieces {
+            piece.text.clear();
+        }
+        return;
+    }
+
+    let width = pieces_width(pieces);
+    if width <= max_width {
+        return;
+    }
+
+    let fixed_width = pieces
+        .iter()
+        .filter(|piece| matches!(piece.kind, RowPieceKind::Fixed))
+        .map(|piece| text_width(&piece.text))
+        .sum::<usize>();
+    if fixed_width >= max_width {
+        let mut used = 0;
+        for piece in pieces {
+            let remaining = max_width.saturating_sub(used);
+            piece.text = truncate_end(&piece.text, remaining);
+            used += text_width(&piece.text);
+            if used >= max_width {
+                break;
+            }
+        }
+        return;
+    }
+
+    for kind in [
+        RowPieceKind::Fields,
+        RowPieceKind::Target,
+        RowPieceKind::Context,
+        RowPieceKind::Location,
+    ] {
+        while pieces_width(pieces) > max_width {
+            let excess = pieces_width(pieces).saturating_sub(max_width);
+            let Some(piece) = pieces.iter_mut().rev().find(|piece| piece.kind == kind) else {
+                break;
+            };
+            let width = text_width(&piece.text);
+            let minimum_width = minimum_piece_width(piece.kind);
+            if width <= minimum_width {
+                break;
+            }
+
+            let target_width = width.saturating_sub(excess).max(minimum_width);
+            piece.text = match piece.kind {
+                RowPieceKind::Context => truncate_start(&piece.text, target_width),
+                _ => truncate_end(&piece.text, target_width),
+            };
+        }
+    }
+
+    if pieces_width(pieces) > max_width {
+        let line = pieces
+            .iter()
+            .map(|piece| piece.text.as_str())
+            .collect::<String>();
+        pieces[0].text = truncate_end(&line, max_width);
+        for piece in &mut pieces[1..] {
+            piece.text.clear();
         }
     }
 }
 
-fn push_target(spans: &mut Vec<Span<'static>>, event: &EventRecord, options: &FormatOptions) {
-    if options.show_target {
-        spans.push(Span::styled(
-            event.target.clone(),
-            Style::default().add_modifier(Modifier::DIM),
-        ));
-        spans.push(Span::styled(
-            ":",
-            Style::default().add_modifier(Modifier::DIM),
-        ));
-        spans.push(Span::raw(" "));
+fn pieces_width(pieces: &[RowPiece]) -> usize {
+    pieces.iter().map(|piece| text_width(&piece.text)).sum()
+}
+
+fn minimum_piece_width(kind: RowPieceKind) -> usize {
+    match kind {
+        RowPieceKind::Fixed => 0,
+        RowPieceKind::Target => 12,
+        RowPieceKind::Context => 24,
+        RowPieceKind::Location => 10,
+        RowPieceKind::Fields => 18,
     }
 }
 
-fn push_message_and_fields(spans: &mut Vec<Span<'static>>, event: &EventRecord) {
-    let fields = event
-        .fields
+fn format_event_fields(fields: &FieldMap) -> String {
+    fields
         .iter()
         .map(|(name, value)| {
             if name == "message" {
@@ -152,39 +275,17 @@ fn push_message_and_fields(spans: &mut Vec<Span<'static>>, event: &EventRecord) 
                 format!("{name}={}", FmtFieldValue(value))
             }
         })
-        .join(" ");
-
-    if !fields.is_empty() {
-        spans.push(Span::raw(fields));
-    }
+        .join(" ")
 }
 
-fn push_location(spans: &mut Vec<Span<'static>>, event: &EventRecord) {
-    let Some(file) = event.file.as_deref() else {
-        return;
-    };
-
-    spans.push(Span::styled(
-        file.to_owned(),
-        Style::default().add_modifier(Modifier::DIM),
-    ));
-    spans.push(Span::styled(
-        ":",
-        Style::default().add_modifier(Modifier::DIM),
-    ));
+fn format_location(event: &EventRecord) -> Option<String> {
+    let file = event.file.as_deref()?;
 
     if let Some(line) = event.line {
-        spans.push(Span::styled(
-            line.to_string(),
-            Style::default().add_modifier(Modifier::DIM),
-        ));
-        spans.push(Span::styled(
-            ":",
-            Style::default().add_modifier(Modifier::DIM),
-        ));
+        return Some(format!("{file}:{line}: "));
     }
 
-    spans.push(Span::raw(" "));
+    Some(format!("{file}: "))
 }
 
 fn format_span_context(span: &SpanRecord) -> String {
@@ -223,11 +324,58 @@ impl std::fmt::Display for FmtFieldValue<'_> {
     }
 }
 
-fn level_span(level: Level) -> Span<'static> {
-    Span::styled(
-        format!("{:<5} ", level.0),
-        Style::default().fg(level_color(level)),
-    )
+fn truncate_end(text: &str, max_width: usize) -> String {
+    truncate(text, max_width, TruncateSide::End)
+}
+
+fn truncate_start(text: &str, max_width: usize) -> String {
+    truncate(text, max_width, TruncateSide::Start)
+}
+
+enum TruncateSide {
+    Start,
+    End,
+}
+
+fn truncate(text: &str, max_width: usize, side: TruncateSide) -> String {
+    if text_width(text) <= max_width {
+        return text.to_owned();
+    }
+
+    if max_width <= OVERFLOW_MARKER.len() {
+        return OVERFLOW_MARKER[..max_width].to_owned();
+    }
+
+    let keep = max_width - OVERFLOW_MARKER.len();
+    match side {
+        TruncateSide::Start => {
+            let suffix = text
+                .chars()
+                .rev()
+                .take(keep)
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .collect::<String>();
+            format!("{OVERFLOW_MARKER}{suffix}")
+        }
+        TruncateSide::End => {
+            let prefix = text.chars().take(keep).collect::<String>();
+            format!("{prefix}{OVERFLOW_MARKER}")
+        }
+    }
+}
+
+fn text_width(text: &str) -> usize {
+    text.chars().count()
+}
+
+fn level_text(level: Level) -> String {
+    format!("{:<5} ", level.0)
+}
+
+fn level_style(level: Level) -> Style {
+    Style::default().fg(level_color(level))
 }
 
 fn level_color(level: Level) -> Color {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,8 @@
 //! the `tracing_subscriber::fmt`-style hierarchy of level, target, span context,
 //! message, and fields. A row should remain useful when an event has no `message`
 //! field because field-only events are valid tracing output.
+//! Long compact-row content is truncated before Ratatui clips the line, with an
+//! inline `...` marker showing that complete data is available in detail.
 //!
 //! Selected-event detail is the full metadata surface. It keeps the complete
 //! timestamp, level, target, module path, source location, promoted message, event

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -193,12 +193,12 @@ impl TraceViewer {
         self.follow_tail();
     }
 
-    fn visible_text(&self, snapshot: &TraceSnapshot) -> Text<'static> {
+    fn visible_text(&self, snapshot: &TraceSnapshot, width: u16) -> Text<'static> {
         let selected_event_id = self.selected_event_id;
         self.visible_events(snapshot)
             .into_iter()
             .map(|event| {
-                let line = event_line(event, snapshot, &self.format);
+                let line = event_line(event, snapshot, &self.format, width);
                 if Some(event.id) == selected_event_id {
                     line.style(Style::default().add_modifier(Modifier::REVERSED))
                 } else {
@@ -338,7 +338,7 @@ fn previous_selected_event_id(
 impl Widget for &mut TraceViewer {
     fn render(self, area: Rect, buf: &mut Buffer) {
         let snapshot = self.store.snapshot();
-        let text = self.visible_text(&snapshot);
+        let text = self.visible_text(&snapshot, area.width);
         let visible_lines = text.lines.len();
         let scroll = self.scroll(visible_lines, area.height);
         Paragraph::new(text).scroll((scroll, 0)).render(area, buf);

--- a/tests/public_workflow.rs
+++ b/tests/public_workflow.rs
@@ -229,6 +229,103 @@ fn viewer_supports_configured_timestamp_formats() {
 }
 
 #[test]
+fn viewer_marks_overflow_for_long_targets() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        tracing::info!(
+            target: "public_workflow::very_long_component_name::deeply_nested_module_name",
+            "connected"
+        );
+    });
+
+    let mut viewer = TraceViewer::new(store);
+    let rendered = render_viewer(&mut viewer, 64, 3);
+    let row = first_non_empty_row(&rendered);
+
+    assert!(row.contains("..."));
+    assert!(row.contains("connected"));
+    assert!(!row.contains("deeply_nested_module_name"));
+}
+
+#[test]
+fn viewer_marks_overflow_for_long_span_context_and_keeps_innermost_span() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        let outer = tracing::info_span!("outer_very_long_span_name", request_id = "req-123456789");
+        let _outer = outer.enter();
+        let middle = tracing::info_span!("middle_very_long_span_name", shard = "checkout-west");
+        let _middle = middle.enter();
+        let inner = tracing::info_span!("inner_important_span", peer = "alpha");
+        let _inner = inner.enter();
+        tracing::warn!("retrying");
+    });
+
+    let mut viewer = TraceViewer::new(store);
+    let rendered = render_viewer(&mut viewer, 96, 3);
+    let row = first_non_empty_row(&rendered);
+
+    assert!(row.contains("..."));
+    assert!(row.contains("inner_important_span"));
+    assert!(row.contains("retrying"));
+}
+
+#[test]
+fn viewer_marks_overflow_for_long_messages() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        tracing::error!(
+            target: "demo",
+            "failed to persist snapshot after repeated retry attempts for local session"
+        );
+    });
+
+    let mut viewer = TraceViewer::new(store);
+    let rendered = render_viewer(&mut viewer, 72, 3);
+    let row = first_non_empty_row(&rendered);
+
+    assert!(row.contains("failed to persist snapshot"));
+    assert!(row.contains("..."));
+    assert!(!row.contains("local session"));
+}
+
+#[test]
+fn viewer_marks_overflow_for_long_fields_but_detail_remains_complete() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+    let value = "field-value-that-is-long-enough-to-overflow-the-compact-row";
+
+    subscriber::with_default(subscriber, || {
+        tracing::info!(target: "demo", payload = value, "stored");
+    });
+
+    let mut viewer = TraceViewer::new(store);
+    let rendered = render_viewer(&mut viewer, 70, 3);
+    let row = first_non_empty_row(&rendered);
+
+    assert!(row.contains("stored"));
+    assert!(row.contains("payload="));
+    assert!(row.contains("..."));
+    assert!(!row.contains("compact-row"));
+
+    viewer.select_first();
+    let detail = viewer
+        .selected_detail()
+        .expect("selected visible event has detail");
+    let rendered = render_detail(&detail, 140, 16);
+
+    assert!(rendered.contains("message: stored"));
+    assert!(
+        rendered.contains("payload: field-value-that-is-long-enough-to-overflow-the-compact-row")
+    );
+}
+
+#[test]
 fn display_filter_does_not_drop_captured_events() {
     let store = TraceStore::default();
     let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));


### PR DESCRIPTION
## Summary

- pass viewport width into compact row formatting
- truncate long targets, span context, messages, and fields with an inline overflow marker
- preserve innermost span context where possible and keep selected detail complete

Closes #14.

Stacked on #38.

## Validation

- just ci
- just demo-gif