### PR TITLE
Add source location controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ For rendering full selected-event context, call `selected_detail()` and render t
 `TraceEventDetail` into a caller-owned pane. Compact row rendering remains fmt-like and optimized
 for scanning: short timestamp, level, target, span context, message, and fields.
 `FormatOptions` can switch compact rows to full RFC 3339 timestamps or a custom Chrono format.
+`TraceViewer::set_show_source_locations` enables source file and line display in compact rows
+without rebuilding the viewer.
 Detail rendering is where full fields, source location, and span-stack context live.
 `TraceEventDetail::text()` exposes the formatted detail text for applications that need their
 own scroll state, borders, titles, or layout chrome around the detail pane.

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -97,7 +97,12 @@ impl App {
             .bg(Color::Blue)
             .add_modifier(Modifier::BOLD);
         let title = Line::from("tui-tracing demo").style(bar_style);
-        let status = demo_status(self.min_level, self.viewer.status()).style(bar_style);
+        let status = demo_status(
+            self.min_level,
+            self.viewer.status(),
+            self.viewer.show_source_locations(),
+        )
+        .style(bar_style);
 
         frame.render_widget(Paragraph::new(title).style(bar_style), title_area);
         if let Some(detail) = self.viewer.selected_detail() {
@@ -128,6 +133,10 @@ impl App {
         match action_for_event(&event) {
             Some(Action::Quit) => self.cancellation_token.cancel(),
             Some(Action::CycleLevel) => self.cycle_level(),
+            Some(Action::ToggleSourceLocations) => {
+                let visible = self.viewer.toggle_source_locations();
+                info!(source_locations = visible, "toggled source locations");
+            }
             Some(Action::SelectNext) => {
                 self.viewer.select_next();
                 self.detail_scroll = 0;
@@ -176,6 +185,7 @@ impl App {
 enum Action {
     Quit,
     CycleLevel,
+    ToggleSourceLocations,
     SelectNext,
     SelectPrevious,
     ClearSelection,
@@ -197,6 +207,7 @@ fn action_for_event(event: &Event) -> Option<Action> {
     match code {
         KeyCode::Char('q') => Some(Action::Quit),
         KeyCode::Char('l') => Some(Action::CycleLevel),
+        KeyCode::Char('s') => Some(Action::ToggleSourceLocations),
         KeyCode::Char('j') => Some(Action::SelectNext),
         KeyCode::Char('k') => Some(Action::SelectPrevious),
         KeyCode::Esc => Some(Action::ClearSelection),
@@ -219,7 +230,11 @@ fn log_ignored_event(event: Event) {
     }
 }
 
-fn demo_status(min_level: Level, status: TraceViewStatus) -> Line<'static> {
+fn demo_status(
+    min_level: Level,
+    status: TraceViewStatus,
+    show_source_locations: bool,
+) -> Line<'static> {
     let mode = match status.scroll_mode {
         TraceScrollMode::FollowTail => "tail",
         TraceScrollMode::Scrollback => "scrollback",
@@ -229,8 +244,14 @@ fn demo_status(min_level: Level, status: TraceViewStatus) -> Line<'static> {
         .map(|index| format!("selected {}/{}", index + 1, status.visible_events))
         .unwrap_or_else(|| "selected none".to_owned());
 
+    let source = if show_source_locations {
+        "source on"
+    } else {
+        "source off"
+    };
+
     Line::from(format!(
-        "q quit | l level {min_level}+ | j/k select | Esc clear | u/d scroll | b/f page | g/G jump | [/] detail | {mode} | {selected} | visible {}/{} | lost {}",
+        "q quit | l level {min_level}+ | s {source} | j/k select | Esc clear | u/d scroll | b/f page | g/G jump | [/] detail | {mode} | {selected} | visible {}/{} | lost {}",
         status.visible_events,
         status.store.retained_events,
         status.store.lost_events()

--- a/src/format.rs
+++ b/src/format.rs
@@ -387,3 +387,46 @@ fn level_color(level: Level) -> Color {
         tracing::Level::ERROR => Color::Red,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use chrono::Local;
+
+    use super::*;
+
+    #[test]
+    fn source_location_uses_file_and_line_when_present() {
+        let event = event_with_location(Some("src/main.rs"), Some(42));
+
+        assert_eq!(format_location(&event), Some("src/main.rs:42: ".to_owned()));
+    }
+
+    #[test]
+    fn source_location_uses_file_without_line_when_line_is_missing() {
+        let event = event_with_location(Some("src/main.rs"), None);
+
+        assert_eq!(format_location(&event), Some("src/main.rs: ".to_owned()));
+    }
+
+    #[test]
+    fn source_location_is_absent_without_file_metadata() {
+        let event = event_with_location(None, Some(42));
+
+        assert_eq!(format_location(&event), None);
+    }
+
+    fn event_with_location(file: Option<&str>, line: Option<u32>) -> EventRecord {
+        EventRecord {
+            id: 0,
+            timestamp: Local::now(),
+            level: Level(tracing::Level::INFO),
+            target: "format_tests".to_owned(),
+            module_path: None,
+            file: file.map(str::to_owned),
+            line,
+            fields: FieldMap::default(),
+            span_id: None,
+            span_stack: Vec::new(),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,12 +85,12 @@
 //!
 //! - set or clear the minimum visible level;
 //! - filter by target, module, span name, text, field name, or field value;
+//! - toggle source locations in compact event rows;
 //! - scroll older or newer;
 //! - move by rendered pages;
 //! - jump to the oldest or newest visible event;
 //! - select previous or next visible event;
 //! - expand selected event details;
-//! - toggle source locations;
 //! - toggle aggregation once grouped rows exist.
 //!
 //! Aggregation belongs on the main screen after the raw event stream is reliable.

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -137,6 +137,32 @@ impl TraceViewer {
         self.format = format;
     }
 
+    /// Return whether compact event rows include source locations.
+    ///
+    /// Source locations are hidden by default because they are often too wide for
+    /// the main event stream. Selected-event detail still includes captured source
+    /// location metadata regardless of this setting.
+    pub fn show_source_locations(&self) -> bool {
+        self.format.show_location
+    }
+
+    /// Set whether compact event rows include source locations.
+    ///
+    /// This updates display formatting only. It does not change captured records,
+    /// active filters, selection, or scroll position.
+    pub fn set_show_source_locations(&mut self, show: bool) {
+        self.format.show_location = show;
+    }
+
+    /// Toggle source locations in compact event rows and return the new value.
+    ///
+    /// This is a convenience for application keybindings. Selected-event detail
+    /// remains complete whether compact rows show source locations or not.
+    pub fn toggle_source_locations(&mut self) -> bool {
+        self.format.show_location = !self.format.show_location;
+        self.format.show_location
+    }
+
     /// Keep the newest visible event pinned to the bottom of the rendered area.
     pub fn follow_tail(&mut self) {
         self.follow_tail = true;

--- a/tapes/demo.tape
+++ b/tapes/demo.tape
@@ -18,6 +18,10 @@ Sleep 4s
 Show
 Sleep 6s
 
+Type "s"
+Sleep 2s
+Type "s"
+Sleep 1s
 Type "j"
 Sleep 1s
 Type "j"

--- a/tapes/selection.tape
+++ b/tapes/selection.tape
@@ -17,6 +17,8 @@ Sleep 4s
 Show
 Sleep 4s
 
+Type "s"
+Sleep 2s
 Type "j"
 Sleep 1s
 Type "j"

--- a/tests/public_workflow.rs
+++ b/tests/public_workflow.rs
@@ -229,6 +229,57 @@ fn viewer_supports_configured_timestamp_formats() {
 }
 
 #[test]
+fn viewer_hides_source_locations_by_default() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        tracing::info!("source hidden");
+    });
+
+    let mut viewer = TraceViewer::new(store);
+    assert!(!viewer.show_source_locations());
+
+    let rendered = render_viewer(&mut viewer, 140, 3);
+
+    assert!(rendered.contains("source hidden"));
+    assert!(!rendered.contains("tests/public_workflow.rs:"));
+}
+
+#[test]
+fn viewer_can_enable_source_locations_without_rebuilding() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        tracing::warn!("source visible");
+    });
+
+    let mut viewer = TraceViewer::new(store);
+    let hidden = render_viewer(&mut viewer, 140, 3);
+    assert!(!hidden.contains("tests/public_workflow.rs:"));
+
+    viewer.set_show_source_locations(true);
+    assert!(viewer.show_source_locations());
+    let visible = render_viewer(&mut viewer, 140, 3);
+
+    assert!(visible.contains("tests/public_workflow.rs:"));
+    assert!(visible.contains("source visible"));
+}
+
+#[test]
+fn viewer_toggles_source_locations_for_keybindings() {
+    let store = TraceStore::default();
+    let mut viewer = TraceViewer::new(store);
+
+    assert!(!viewer.show_source_locations());
+    assert!(viewer.toggle_source_locations());
+    assert!(viewer.show_source_locations());
+    assert!(!viewer.toggle_source_locations());
+    assert!(!viewer.show_source_locations());
+}
+
+#[test]
 fn viewer_marks_overflow_for_long_targets() {
     let store = TraceStore::default();
     let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));


### PR DESCRIPTION
## Summary

- add first-class TraceViewer source-location controls
- wire the demo status bar and s key to toggle compact-row locations
- document compact-row source display and update VHS tapes

Closes #15.

## Validation

- just ci
- just demo-gif