### PR TITLE
Refine trace presentation hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ to mark overflow. Span context truncates from the left so the innermost span rem
 possible. The selected-event detail remains complete.
 
 Selected-event detail keeps the complete timestamp, target, module path, source location, promoted
-message, event fields, span stack, span fields, lifecycle state, and timing data.
+message, event fields, span stack, span fields, lifecycle state, and timing data. Its layout and
+styling should communicate ownership: event fields are nested under the event, span fields are
+nested under their span, and the span stack is context for the selected event.
 
 Span trees, timing summaries, and aggregation are secondary views built from the same retained
 records. Nesting is important data, but it should not dominate the first diagnostic view.
@@ -103,7 +105,9 @@ for scanning: short timestamp, level, target, span context, message, and fields.
 `FormatOptions` can switch compact rows to full RFC 3339 timestamps or a custom Chrono format.
 `TraceViewer::set_show_source_locations` enables source file and line display in compact rows
 without rebuilding the viewer.
-Detail rendering is where full fields, source location, and span-stack context live.
+Detail rendering is where full fields, source location, and span-stack context live. Its styling
+uses a small palette and indentation to show how metadata, fields, and span context relate without
+turning the pane into a color legend.
 `TraceEventDetail::text()` exposes the formatted detail text for applications that need their
 own scroll state, borders, titles, or layout chrome around the detail pane.
 

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -10,7 +10,7 @@ use ratatui::crossterm::event::EventStream;
 use ratatui::layout::{Constraint, Layout};
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::Line;
-use ratatui::widgets::{Block, Paragraph};
+use ratatui::widgets::{Block, Borders, Paragraph};
 use ratatui::DefaultTerminal;
 use tokio::time::MissedTickBehavior;
 use tokio_util::sync::CancellationToken;
@@ -107,10 +107,11 @@ impl App {
         frame.render_widget(Paragraph::new(title).style(bar_style), title_area);
         if let Some(detail) = self.viewer.selected_detail() {
             let [trace_area, detail_area] =
-                Layout::vertical([Constraint::Percentage(58), Constraint::Percentage(42)])
+                Layout::vertical([Constraint::Percentage(52), Constraint::Percentage(48)])
                     .areas(trace_area);
             frame.render_widget(&mut self.viewer, trace_area);
-            let detail_block = Block::bordered()
+            let detail_block = Block::default()
+                .borders(Borders::TOP)
                 .title(" selected event detail ")
                 .border_style(Style::default().fg(Color::Cyan));
             let detail = Paragraph::new(detail.text())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,9 @@
 //! Selected-event detail is the full metadata surface. It keeps the complete
 //! timestamp, level, target, module path, source location, promoted message, event
 //! fields, full span stack, span fields, lifecycle state, and timing.
+//! Detail styling uses restrained color and indentation to show ownership:
+//! metadata and fields belong to the selected event, and span fields belong to
+//! the span context around that event.
 //!
 //! The main screen should expose behavior that applications can bind to their own
 //! input model:

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -422,12 +422,12 @@ impl TraceEventDetail {
     pub fn text(&self) -> Text<'static> {
         let mut lines = vec![
             heading("Event"),
-            detail_line("time", self.event.timestamp.to_rfc3339()),
-            detail_line("level", self.event.level.0.to_string()),
-            detail_line("target", self.event.target.clone()),
-            metadata_line("  module", self.event.module_path.as_deref()),
+            metadata_line("time", self.event.timestamp.to_rfc3339()),
+            metadata_line("level", self.event.level.0.to_string()),
+            metadata_line("target", self.event.target.clone()),
+            optional_metadata_line("  module", self.event.module_path.as_deref()),
             location_line("  location", self.event.file.as_deref(), self.event.line),
-            detail_line(
+            message_line(
                 "message",
                 self.event
                     .fields
@@ -486,30 +486,30 @@ impl TraceSpanDetail {
 }
 
 fn push_fields(lines: &mut Vec<Line<'static>>, heading: &'static str, fields: &FieldMap) {
-    lines.push(heading_line(heading));
+    lines.push(span_fields_heading(heading));
     if fields.is_empty() {
-        lines.push(muted_line("  <none>"));
+        lines.push(muted_line("        <none>"));
         return;
     }
 
     for (name, value) in fields {
-        lines.push(detail_line(name, value.to_string()));
+        lines.push(span_field_line(name, value.to_string()));
     }
 }
 
 fn push_event_fields(lines: &mut Vec<Line<'static>>, fields: &FieldMap) {
-    lines.push(heading_line("Fields"));
+    lines.push(event_fields_heading("  fields"));
     let mut pushed = false;
     for (name, value) in fields {
         if name == "message" {
             continue;
         }
-        lines.push(detail_line(name, value.to_string()));
+        lines.push(event_field_line(name, value.to_string()));
         pushed = true;
     }
 
     if !pushed {
-        lines.push(muted_line("  <none>"));
+        lines.push(muted_line("     <none>"));
     }
 }
 
@@ -534,27 +534,22 @@ fn push_span_stack(lines: &mut Vec<Line<'static>>, span_stack: &[TraceSpanDetail
 
 fn push_span(lines: &mut Vec<Line<'static>>, index: usize, span: &SpanRecord) {
     lines.push(Line::from(vec![
-        Span::styled(
-            format!("  {index}. "),
-            Style::default().add_modifier(Modifier::DIM),
-        ),
-        Span::styled(
-            span.name.clone(),
-            Style::default()
-                .fg(Color::Cyan)
-                .add_modifier(Modifier::BOLD),
-        ),
+        Span::styled(format!("  {index}. "), span_index_style()),
+        Span::styled(span.name.clone(), span_name_style()),
     ]));
-    lines.push(indented_detail_line("id", span.id.to_string()));
-    lines.push(indented_detail_line("level", span.level.0.to_string()));
-    lines.push(indented_detail_line("target", span.target.clone()));
-    lines.push(metadata_line("     module", span.module_path.as_deref()));
+    lines.push(span_metadata_line("id", span.id.to_string()));
+    lines.push(span_metadata_line("level", span.level.0.to_string()));
+    lines.push(span_metadata_line("target", span.target.clone()));
+    lines.push(optional_span_metadata_line(
+        "     module",
+        span.module_path.as_deref(),
+    ));
     lines.push(location_line(
         "     location",
         span.file.as_deref(),
         span.line,
     ));
-    lines.push(indented_detail_line(
+    lines.push(span_metadata_line(
         "lifecycle",
         if span.close_time.is_some() {
             "closed"
@@ -564,7 +559,7 @@ fn push_span(lines: &mut Vec<Line<'static>>, index: usize, span: &SpanRecord) {
     ));
 
     if let Some(timing) = span.timing {
-        lines.push(indented_detail_line(
+        lines.push(span_metadata_line(
             "timing",
             format!(
                 "state={:?} busy={:?} idle={:?} total={:?} enters={} exits={}",
@@ -581,46 +576,101 @@ fn push_span(lines: &mut Vec<Line<'static>>, index: usize, span: &SpanRecord) {
 }
 
 fn heading(label: &'static str) -> Line<'static> {
-    Line::from(label).style(
-        Style::default()
-            .fg(Color::Cyan)
-            .add_modifier(Modifier::BOLD),
+    Line::from(label).style(section_heading_style())
+}
+
+fn event_fields_heading(label: &'static str) -> Line<'static> {
+    Line::from(label).style(subsection_heading_style())
+}
+
+fn span_fields_heading(label: &'static str) -> Line<'static> {
+    Line::from(label).style(subsection_heading_style())
+}
+
+fn metadata_line(label: impl Into<String>, value: impl Into<String>) -> Line<'static> {
+    field_line(
+        "  ",
+        label,
+        value,
+        metadata_label_style(),
+        metadata_value_style(),
     )
 }
 
-fn heading_line(label: &'static str) -> Line<'static> {
-    Line::from(label).style(Style::default().fg(Color::Yellow))
+fn optional_metadata_line(label: &'static str, value: Option<&str>) -> Line<'static> {
+    labeled_line(
+        label,
+        value.unwrap_or("<unknown>").to_owned(),
+        metadata_label_style(),
+        metadata_value_style_for(value),
+    )
 }
 
-fn detail_line(label: impl Into<String>, value: impl Into<String>) -> Line<'static> {
-    field_line("  ", label, value)
+fn message_line(label: impl Into<String>, value: impl Into<String>) -> Line<'static> {
+    let value = value.into();
+    let value_style = if value == "<none>" {
+        missing_value_style()
+    } else {
+        value_style()
+    };
+    field_line("  ", label, value, message_label_style(), value_style)
 }
 
-fn indented_detail_line(label: impl Into<String>, value: impl Into<String>) -> Line<'static> {
-    field_line("     ", label, value)
+fn event_field_line(label: impl Into<String>, value: impl Into<String>) -> Line<'static> {
+    field_line(
+        "     ",
+        label,
+        value,
+        event_field_label_style(),
+        value_style(),
+    )
+}
+
+fn span_metadata_line(label: impl Into<String>, value: impl Into<String>) -> Line<'static> {
+    field_line(
+        "     ",
+        label,
+        value,
+        metadata_label_style(),
+        metadata_value_style(),
+    )
+}
+
+fn optional_span_metadata_line(label: &'static str, value: Option<&str>) -> Line<'static> {
+    labeled_line(
+        label,
+        value.unwrap_or("<unknown>").to_owned(),
+        metadata_label_style(),
+        metadata_value_style_for(value),
+    )
+}
+
+fn span_field_line(label: impl Into<String>, value: impl Into<String>) -> Line<'static> {
+    field_line(
+        "        ",
+        label,
+        value,
+        span_field_label_style(),
+        value_style(),
+    )
 }
 
 fn field_line(
     prefix: &'static str,
     label: impl Into<String>,
     value: impl Into<String>,
+    label_style: Style,
+    value_style: Style,
 ) -> Line<'static> {
     Line::from(vec![
-        Span::styled(
-            format!("{prefix}{}:", label.into()),
-            Style::default().fg(Color::Blue),
-        ),
+        Span::styled(format!("{prefix}{}:", label.into()), label_style),
         Span::raw(" "),
-        Span::raw(value.into()),
+        Span::styled(value.into(), value_style),
     ])
 }
 
 fn muted_line(text: impl Into<String>) -> Line<'static> {
-    Line::from(text.into()).style(Style::default().add_modifier(Modifier::DIM))
-}
-
-fn metadata_line(label: &'static str, value: Option<&str>) -> Line<'static> {
-    labeled_line(label, value.unwrap_or("<unknown>").to_owned())
+    Line::from(text.into()).style(missing_value_style())
 }
 
 fn location_line(label: &'static str, file: Option<&str>, line: Option<u32>) -> Line<'static> {
@@ -630,13 +680,85 @@ fn location_line(label: &'static str, file: Option<&str>, line: Option<u32>) -> 
         (None, Some(line)) => format!("<unknown>:{line}"),
         (None, None) => "<unknown>".to_owned(),
     };
-    labeled_line(label, value)
+    let style = if file.is_some() {
+        metadata_value_style()
+    } else {
+        missing_value_style()
+    };
+    labeled_line(label, value, metadata_label_style(), style)
 }
 
-fn labeled_line(label: &'static str, value: impl Into<String>) -> Line<'static> {
+fn labeled_line(
+    label: &'static str,
+    value: impl Into<String>,
+    label_style: Style,
+    value_style: Style,
+) -> Line<'static> {
     let prefix_len = label.len() - label.trim_start().len();
     let (prefix, label) = label.split_at(prefix_len);
-    field_line(prefix, label, value)
+    field_line(prefix, label, value, label_style, value_style)
+}
+
+fn section_heading_style() -> Style {
+    Style::default()
+        .fg(Color::Cyan)
+        .add_modifier(Modifier::BOLD)
+}
+
+fn subsection_heading_style() -> Style {
+    Style::default()
+        .fg(Color::Gray)
+        .add_modifier(Modifier::BOLD)
+}
+
+fn metadata_label_style() -> Style {
+    Style::default().fg(Color::Gray)
+}
+
+fn metadata_value_style() -> Style {
+    Style::default()
+}
+
+fn metadata_value_style_for(value: Option<&str>) -> Style {
+    if value.is_some() {
+        metadata_value_style()
+    } else {
+        missing_value_style()
+    }
+}
+
+fn message_label_style() -> Style {
+    Style::default().fg(Color::Gray)
+}
+
+fn event_field_label_style() -> Style {
+    Style::default().fg(Color::Gray)
+}
+
+fn span_field_label_style() -> Style {
+    Style::default().fg(Color::Gray)
+}
+
+fn value_style() -> Style {
+    Style::default()
+}
+
+fn missing_value_style() -> Style {
+    Style::default()
+        .fg(Color::DarkGray)
+        .add_modifier(Modifier::DIM)
+}
+
+fn span_index_style() -> Style {
+    Style::default()
+        .fg(Color::DarkGray)
+        .add_modifier(Modifier::DIM)
+}
+
+fn span_name_style() -> Style {
+    Style::default()
+        .fg(Color::Cyan)
+        .add_modifier(Modifier::BOLD)
 }
 
 /// Current scrolling mode for a [`TraceViewer`].

--- a/tests/public_workflow.rs
+++ b/tests/public_workflow.rs
@@ -1,4 +1,6 @@
 use ratatui::backend::TestBackend;
+use ratatui::buffer::Buffer;
+use ratatui::style::{Color, Modifier};
 use ratatui::Terminal;
 use tracing::subscriber;
 use tracing_subscriber::layer::SubscriberExt;
@@ -645,7 +647,7 @@ fn selected_detail_renders_event_fields_span_fields_and_source_location() {
             "module:",
             "location:",
             "message:",
-            "Fields",
+            "fields",
             "answer:",
             "Span stack",
             "0. request",
@@ -654,6 +656,35 @@ fn selected_detail_renders_event_fields_span_fields_and_source_location() {
             "user:",
         ],
     );
+}
+
+#[test]
+fn selected_detail_styles_event_and_span_hierarchy() {
+    let store = TraceStore::default();
+    let subscriber = Registry::default().with(TraceLayer::from_store(store.clone()));
+
+    subscriber::with_default(subscriber, || {
+        let span = tracing::info_span!("request", user = "alice");
+        let _guard = span.enter();
+        tracing::warn!(answer = 42, "payment declined");
+    });
+
+    let mut viewer = TraceViewer::new(store);
+    viewer.select_first();
+    let detail = viewer
+        .selected_detail()
+        .expect("selected visible event has renderable detail");
+    let buffer = render_detail_buffer(&detail, 120, 24);
+
+    assert_cell_style(&buffer, "Event", Color::Cyan, Modifier::BOLD);
+    assert_cell_style(&buffer, "message:", Color::Gray, Modifier::empty());
+    assert_cell_style(&buffer, "WARN", Color::Reset, Modifier::empty());
+    assert_cell_style(&buffer, "fields", Color::Gray, Modifier::BOLD);
+    assert_cell_style(&buffer, "answer:", Color::Gray, Modifier::empty());
+    assert_cell_style(&buffer, "Span stack", Color::Cyan, Modifier::BOLD);
+    assert_cell_style(&buffer, "0.", Color::DarkGray, Modifier::DIM);
+    assert_cell_style(&buffer, "request", Color::Cyan, Modifier::BOLD);
+    assert_cell_style(&buffer, "user:", Color::Gray, Modifier::empty());
 }
 
 #[test]
@@ -713,6 +744,28 @@ fn event_detail_renders_missing_source_location_and_missing_span_records() {
     assert!(rendered.contains("message: synthetic"));
     assert!(rendered.contains("code: 503"));
     assert!(rendered.contains("<missing span 99>"));
+}
+
+#[test]
+fn selected_detail_styles_missing_values() {
+    let event = EventRecord {
+        id: 7,
+        timestamp: chrono::Local::now(),
+        level: Level(tracing::Level::ERROR),
+        target: "synthetic::target".to_owned(),
+        module_path: None,
+        file: None,
+        line: None,
+        fields: FieldMap::default(),
+        span_id: Some(99),
+        span_stack: vec![99],
+    };
+    let detail = TraceEventDetail::new(event, vec![TraceSpanDetail::missing(99)]);
+    let buffer = render_detail_buffer(&detail, 100, 16);
+
+    assert_cell_style(&buffer, "<unknown>", Color::DarkGray, Modifier::DIM);
+    assert_cell_style(&buffer, "<none>", Color::DarkGray, Modifier::DIM);
+    assert_cell_style(&buffer, "<missing span 99>", Color::DarkGray, Modifier::DIM);
 }
 
 #[test]
@@ -971,12 +1024,16 @@ fn render_viewer_event_rows(viewer: &mut TraceViewer, width: u16, height: u16) -
 }
 
 fn render_detail(detail: &TraceEventDetail, width: u16, height: u16) -> String {
+    buffer_rows(&render_detail_buffer(detail, width, height)).join("\n")
+}
+
+fn render_detail_buffer(detail: &TraceEventDetail, width: u16, height: u16) -> Buffer {
     let backend = TestBackend::new(width, height);
     let mut terminal = Terminal::new(backend).unwrap();
     terminal
         .draw(|frame| frame.render_widget(detail, frame.area()))
         .unwrap();
-    buffer_rows(terminal.backend().buffer()).join("\n")
+    terminal.backend().buffer().clone()
 }
 
 fn first_non_empty_row(rendered: &str) -> &str {
@@ -994,6 +1051,36 @@ fn assert_ordered(rendered: &str, needles: &[&str]) {
             .unwrap_or_else(|| panic!("expected {needle:?} after byte {start} in:\n{rendered}"));
         start += offset + needle.len();
     }
+}
+
+fn assert_cell_style(buffer: &Buffer, text: &str, fg: Color, modifier: Modifier) {
+    let (x, y) = find_text(buffer, text);
+    let cell = buffer
+        .cell((x, y))
+        .expect("text coordinate points inside the buffer");
+    assert_eq!(cell.fg, fg, "foreground for {text:?}");
+    assert!(
+        cell.modifier.contains(modifier),
+        "modifier for {text:?}: expected {:?} in {:?}",
+        modifier,
+        cell.modifier
+    );
+}
+
+fn find_text(buffer: &Buffer, text: &str) -> (u16, u16) {
+    let area = buffer.area;
+    for y in area.y..area.y + area.height {
+        let row = (area.x..area.x + area.width)
+            .filter_map(|x| buffer.cell((x, y)).map(|cell| cell.symbol()))
+            .collect::<String>();
+        if let Some(x) = row.find(text) {
+            return (u16::try_from(x).expect("test buffer width fits in u16"), y);
+        }
+    }
+    panic!(
+        "expected to find {text:?} in:\n{}",
+        buffer_rows(buffer).join("\n")
+    );
 }
 
 fn buffer_rows(buffer: &ratatui::buffer::Buffer) -> Vec<String> {


### PR DESCRIPTION
## Summary

- make compact rows hide span context by default while keeping it configurable
- add TraceViewer span-context controls and demo c key/status wiring
- make selected detail use restrained styles and nested field groups to show ownership
- expand the demo detail pane and use top-only detail chrome
- add Ratatui buffer-cell tests for important detail style choices

Closes #36.
Revisits #37 compact row hierarchy.

## Validation

- just ci
- just demo-gif