### PR TITLE
Improve library documentation

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,3 +1,5 @@
 config:
   MD013:
     line_length: 100
+  MD024:
+    siblings_only: true

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # Tui-tracing
 
-`tui-tracing` is a native `tracing` viewer for Ratatui applications.
+`tui-tracing` is a runtime store and widget for displaying [`tracing`] events inside
+[`ratatui`]-based applications.
 
 ![tui-tracing demo](https://github.com/joshka/tui-tracing/releases/latest/download/tui-tracing-demo.gif)
 
 It is inspired by `tui-logger`, but it does not treat tracing as log compatibility glue. The
-crate captures spans, events, fields, timing, and span context directly from `tracing-subscriber`
+crate captures spans, events, fields, timing, and span context directly from [`tracing-subscriber`]
 so a running TUI can inspect more information than it currently displays.
 
 Status: experimental pre-release API.
@@ -19,9 +20,9 @@ at your option.
 
 ## Design Direction
 
-The default viewer is event-stream-first. It should feel familiar to users of
-`tracing_subscriber::fmt`: colored levels, readable timestamps, messages, structured fields, and
-optional compact span context.
+The default viewer is event-stream-first. It should feel familiar to users of the
+[`tracing_subscriber::fmt`] formatter: colored levels, readable timestamps, messages, structured
+fields, and optional compact span context.
 
 Compact rows default to a short local timestamp so they fit inside an application pane:
 
@@ -48,18 +49,18 @@ records. Nesting is important data, but it should not dominate the first diagnos
 
 `tui-tracing` separates capture from display:
 
-1. `TraceLayer` captures structured tracing records into `TraceStore`.
+1. [`TraceLayer`] captures structured tracing records into [`TraceStore`].
 1. The application keeps the store in runtime state.
-1. `TraceViewer` renders retained records in a Ratatui widget.
-1. `TraceFilter` changes what is shown without losing captured data.
+1. [`TraceViewer`] renders retained records in a [`ratatui`] widget.
+1. [`TraceFilter`] changes what is shown without losing captured data.
 
 Capture-time filtering is still useful for cost control. Display-time filtering is the main
 interaction model for diagnostics inside a running TUI.
 
-`TraceStore::status()` exposes cheap storage counters for status bars and diagnostics: configured
+[`TraceStore::status`] exposes cheap storage counters for status bars and diagnostics: configured
 capacity, retained events, retained spans, captured events, accepted events, evicted events, and
 dropped events. These counters describe storage behavior before display-time filtering, so hiding
-an event with `TraceFilter` does not change the captured, evicted, or dropped totals. The returned
+an event with [`TraceFilter`] does not change the captured, evicted, or dropped totals. The returned
 status also has helpers for common status-bar decisions such as empty state, remaining event
 capacity, capacity pressure, and whether any captured event has been lost.
 
@@ -85,49 +86,48 @@ terminal
     .unwrap();
 ```
 
-`TraceViewer` intentionally implements `Widget` for `&mut TraceViewer`. The viewer must update
+[`TraceViewer`] intentionally implements [`Widget`] for `&mut TraceViewer`. The viewer must update
 scroll state during rendering because the tail position depends on the rendered height and the
 current number of visible rows. That value is only known once the host application chooses a
 layout area for the widget.
 
-The practical effect is that applications can keep `TraceViewer` directly in app state, mutate it
-through methods such as `set_filter`, `scroll_up`, `scroll_down`, `page_up`, `page_down`,
-`jump_to_oldest`, and `jump_to_newest`, and then render `&mut viewer` in the area they assign to
-trace output. This avoids `StatefulWidget` while still preserving correct follow-tail and
-scrollback behavior.
+Applications can keep [`TraceViewer`] directly in app state, mutate it through methods such as
+`set_filter`, `scroll_up`, `scroll_down`, `page_up`, `page_down`, `jump_to_oldest`, and
+`jump_to_newest`, and render `&mut viewer` in the area assigned to trace output. The API avoids
+[`StatefulWidget`] while preserving follow-tail and scrollback behavior.
 
-Applications can call `TraceViewer::status()` to build their own status bars without duplicating
+Applications can call [`TraceViewer::status`] to build their own status bars without duplicating
 viewer logic. The returned status includes follow-tail versus scrollback mode, the last computed
 scroll offsets, visible and hidden event counts after display filtering, selected visible row
 state, the active filter, and the underlying `TraceStoreStatus`.
 
 Selection is tracked by retained event id and interpreted through the active display filter.
 Applications can move selection with `select_next`, `select_previous`, `select_first`, and
-`select_last`, then read `selected_event` or `TraceViewer::status()` for app-owned detail views.
-For rendering full selected-event context, call `selected_detail()` and render the returned
-`TraceEventDetail` into a caller-owned pane. Compact row rendering remains fmt-like and optimized
+`select_last`, then read `selected_event` or [`TraceViewer::status`] for app-owned detail views.
+For rendering full selected-event context, call [`TraceViewer::selected_detail`] and render the returned
+[`TraceEventDetail`] into a caller-owned pane. Compact row rendering remains fmt-like and optimized
 for scanning: short timestamp, level, target, message, and fields.
-`FormatOptions` can switch compact rows to full RFC 3339 timestamps or a custom Chrono format.
-`TraceViewer::set_show_span_context` enables inline span context for applications that want
+[`FormatOptions`] can switch compact rows to full RFC 3339 timestamps or a custom [`chrono`] format.
+[`TraceViewer::set_show_span_context`] enables inline span context for applications that want
 fmt-style span names in compact rows.
-`TraceViewer::set_show_source_locations` enables source file and line display in compact rows
+[`TraceViewer::set_show_source_locations`] enables source file and line display in compact rows
 without rebuilding the viewer.
 Detail rendering is where full fields, source location, and span-stack context live. Its styling
 uses a small palette and indentation to show how metadata, fields, and span context relate without
 turning the pane into a color legend.
-`TraceEventDetail::text()` exposes the formatted detail text for applications that need their
+[`TraceEventDetail::text`] exposes the formatted detail text for applications that need their
 own scroll state, borders, titles, or layout chrome around the detail pane.
 
 ## Current Public Path
 
-- `TraceLayer`: subscriber layer for capture.
-- `TraceStore`: shared runtime buffer of retained records and storage counters.
-- `TraceViewer`: Ratatui event-stream viewer.
-- `TraceEventDetail`: renderable selected-event detail.
-- `TraceFilter`: display-time event filter.
-- `FormatOptions`: compact row formatting options.
-- `TimingLayer`: optional span busy/idle timing layer.
-- `TimingState`: span timing lifecycle state.
+- [`TraceLayer`]: subscriber layer for capture.
+- [`TraceStore`]: shared runtime buffer of retained records and storage counters.
+- [`TraceViewer`]: [`ratatui`] event-stream viewer.
+- [`TraceEventDetail`]: renderable selected-event detail.
+- [`TraceFilter`]: display-time event filter.
+- [`FormatOptions`]: compact row formatting options.
+- [`TimingLayer`]: optional span busy/idle timing layer.
+- [`TimingState`]: span timing lifecycle state.
 
 The demo in `examples/demo.rs` is intentionally small and should stay aligned with the public API
 path above.
@@ -137,8 +137,8 @@ path above.
 - Aggregation of repeated events is not implemented yet.
 - The default viewer is intentionally simple and does not yet expose secondary span-tree or timing
   views.
-- The timing layer remains local to this crate. The related upstream tracing PR did not appear to
-  land as a stable `tracing-subscriber` API.
+- The timing layer remains local to this crate. The related upstream [`tracing`] PR did not appear
+  to land as a stable [`tracing-subscriber`] API.
 - Expanded details, grouped rows, page movement, and higher-level viewer status summaries are
   planned follow-up work rather than part of the initial viewer surface.
 
@@ -158,3 +158,25 @@ just ci
 
 The `rustfmt.toml` matches the formatting posture used by `../async-tty` and requires nightly
 rustfmt for the configured unstable formatting options.
+
+[`formatoptions`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.FormatOptions.html
+[`chrono`]: https://docs.rs/chrono/latest/chrono/
+[`ratatui`]: https://docs.rs/ratatui/latest/ratatui/
+[`statefulwidget`]: https://docs.rs/ratatui/latest/ratatui/widgets/trait.StatefulWidget.html
+[`timinglayer`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TimingLayer.html
+[`timingstate`]: https://docs.rs/tui-tracing/latest/tui_tracing/enum.TimingState.html
+[`traceeventdetail`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceEventDetail.html
+[`traceeventdetail::text`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceEventDetail.html#method.text
+[`tracefilter`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceFilter.html
+[`tracelayer`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceLayer.html
+[`tracestore`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceStore.html
+[`tracestore::status`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceStore.html#method.status
+[`traceviewer`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceViewer.html
+[`traceviewer::selected_detail`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceViewer.html#method.selected_detail
+[`traceviewer::set_show_source_locations`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceViewer.html#method.set_show_source_locations
+[`traceviewer::set_show_span_context`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceViewer.html#method.set_show_span_context
+[`traceviewer::status`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceViewer.html#method.status
+[`tracing`]: https://docs.rs/tracing/latest/tracing/
+[`tracing-subscriber`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/
+[`tracing_subscriber::fmt`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/
+[`widget`]: https://docs.rs/ratatui/latest/ratatui/widgets/trait.Widget.html

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -1,15 +1,13 @@
 # Design And Quality Standards
 
-This document is durable guidance for `tui-tracing`. It is the source of truth for the
-maintenance posture expected from implementation, documentation, tests, and automation.
+Durable guidance for `tui-tracing` defines the maintenance posture expected from implementation,
+documentation, tests, and automation.
 
 ## Library Goal
 
-Build this as a production-quality Rust library, optimized for long-term maintenance, reader
-clarity, and idiomatic public API design.
-
-The goal is not just to make the code work. The goal is to make the crate easy to understand,
-easy to audit, easy to extend, and hard to misuse.
+Build `tui-tracing` as a production-quality Rust library, optimized for long-term maintenance,
+reader clarity, and idiomatic public API design. Working code is not enough; the crate should be
+easy to understand, audit, extend, and use correctly.
 
 ## General Standards
 
@@ -38,7 +36,7 @@ easy to audit, easy to extend, and hard to misuse.
   responsibility.
 - Use `From`, `TryFrom`, `Default`, `Display`, and common derives where they make value types
   easier and safer to use without weakening invariants.
-- Public error enums should usually be `#[non_exhaustive]` unless exhaustive matching is
+- Public error enums should default to `#[non_exhaustive]` unless exhaustive matching is
   intentional.
 - Avoid giant crate roots. The root should teach the crate, expose the primary path, and point to
   deeper modules.
@@ -57,20 +55,34 @@ easy to audit, easy to extend, and hard to misuse.
 ## Documentation Standards
 
 - Treat rustdoc as part of the API, not decoration.
-- Each public module should answer what concept it owns, when to use it, what to read next, and
+- The crate root should route new users with a purpose statement, first example, primary public
+  entry points, module map, feature flags, examples, and lifecycle notes.
+- Every public module should answer what concept it owns, the main workflow, related modules, and
   what it intentionally does not own.
-- Provide guide-level docs as well as reference docs: tutorials for first success, how-tos for
-  common tasks, explanations for core concepts, and reference docs for exact API behavior.
-- Write docs for non-linear readers. Someone may land on any module, type, example, or guide
-  first.
-- Make start-here paths obvious.
-- Distinguish user docs, maintainer docs, design notes, release checklists, and historical review
-  docs.
-- Cross-link docs directionally: start here, source of truth, read next, and related lower-level
-  detail.
+- Every public type should explain what it represents, who should construct it, what invariants it
+  preserves, lifecycle or ownership behavior, concurrency expectations where relevant, and how it
+  relates to neighboring types.
+- Every public field should document meaning, valid values or invariants, default behavior, and
+  interactions with other fields.
+- Every public function should document caller-facing behavior, state changes, side effects, and
+  allocation, blocking, I/O, global registration, or background work when relevant.
+- Fallible APIs should explain what can fail, whether retrying is useful, whether partial state may
+  have changed, and how callers recover.
+- APIs that change process-wide, runtime-wide, global, UI, subscriber, terminal, file, network, or
+  background-task state must document ownership, startup, shutdown, cleanup, drop behavior, and
+  whether multiple instances may coexist.
+- Async or concurrent APIs should document runtime assumptions, cancellation, backpressure,
+  capacity, ordering, cloneability, and producer/consumer lifetime behavior.
+- Feature-gated APIs should document the feature name, why it exists, what it enables, and whether
+  it changes public API, runtime behavior, dependencies, examples, or platform support.
+- Write docs for non-linear readers. Someone may land on any module, type, example, or guide first.
+- Cross-link docs to owning modules, related types, runnable examples, tests, and lower-level
+  details where those links improve auditability.
 - Examples should show practical use, not just construction.
 - Prefer simple, obvious examples over elaborate mini-frameworks.
 - Use realistic examples that teach ownership, lifecycle, errors, or integration shape.
+- Markdown docs should be reserved for material that does not fit in rustdoc or README: quality
+  standards, release procedure, design tradeoffs, and maintainer workflows.
 
 ## Testing Standards
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,0 +1,38 @@
+use ratatui::Terminal;
+use ratatui::backend::TestBackend;
+use tracing::subscriber;
+use tracing_subscriber::Registry;
+use tracing_subscriber::layer::SubscriberExt;
+use tui_tracing::{TraceFilter, TraceLayer, TraceViewer};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let (layer, store) = TraceLayer::new();
+    let subscriber = Registry::default().with(layer);
+
+    subscriber::with_default(subscriber, || {
+        let span = tracing::info_span!("startup", component = "example");
+        let _guard = span.enter();
+        tracing::info!(ready = true, "application ready");
+        tracing::debug!(cache_entries = 3, "cache warmed");
+    });
+
+    let mut viewer = TraceViewer::new(store);
+    viewer.set_filter(TraceFilter::all().with_min_level(tracing::Level::INFO));
+
+    let backend = TestBackend::new(100, 4);
+    let mut terminal = Terminal::new(backend)?;
+    terminal.draw(|frame| frame.render_widget(&mut viewer, frame.area()))?;
+
+    let buffer = terminal.backend().buffer();
+    let area = buffer.area;
+    for y in area.y..area.y + area.height {
+        for x in area.x..area.x + area.width {
+            if let Some(cell) = buffer.cell((x, y)) {
+                print!("{}", cell.symbol());
+            }
+        }
+        println!();
+    }
+
+    Ok(())
+}

--- a/justfile
+++ b/justfile
@@ -21,6 +21,9 @@ clippy:
 doc:
     RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
 
+docs-rs:
+    RUSTDOCFLAGS="-D warnings" cargo +nightly docs-rs
+
 markdown:
     markdownlint-cli2 README.md "docs/**/*.md"
 
@@ -33,7 +36,7 @@ audit:
 machete:
     cargo machete
 
-ci: fmt-check check test clippy doc markdown package audit machete
+ci: fmt-check check test clippy doc docs-rs markdown package audit machete
 
 demo-gif:
     mkdir -p target/vhs

--- a/src/field.rs
+++ b/src/field.rs
@@ -1,8 +1,23 @@
-//! Structured field values captured from `tracing` spans and events.
+//! Structured field values captured from [`tracing`] spans and events.
 //!
 //! This module owns the crate's field representation. Capture layers convert
-//! `tracing` visitor callbacks into [`FieldValue`] values, and display code later
+//! [`tracing`] visitor callbacks into [`FieldValue`] values, and display code later
 //! formats those values without needing access to the original subscriber context.
+//!
+//! # Common Workflow
+//!
+//! Most applications do not construct field maps directly. [`crate::TraceLayer`]
+//! records fields into [`FieldMap`], [`crate::TraceStore`] retains them, and
+//! [`crate::TraceViewer`] formats them.
+//!
+//! Read this module when you need to inspect retained [`crate::EventRecord`] or
+//! [`crate::SpanRecord`] values yourself.
+//!
+//! # Related Modules
+//!
+//! - [`crate::record`] stores captured fields on events and spans.
+//! - [`crate::filter`] searches field names and values at display time.
+//! - [`crate::viewer`] renders fields in compact rows and selected-event detail.
 
 use std::error::Error;
 use std::fmt;
@@ -13,15 +28,23 @@ use tracing_subscriber::field::VisitOutput;
 
 /// Ordered map of structured tracing fields.
 ///
-/// Field order follows the order in which `tracing` records the fields. The display
-/// layer keeps that order so output remains close to `tracing_subscriber::fmt`.
+/// Field order follows the order in which [`tracing`] records the fields. The display
+/// layer keeps that order so output remains close to
+/// [`tracing_subscriber::fmt`](mod@tracing_subscriber::fmt).
+///
+/// The map is owned data. Captured field values never borrow from the original
+/// tracing call site, so snapshots can outlive the subscriber callback that
+/// produced them.
 pub type FieldMap = IndexMap<String, FieldValue>;
 
 /// A structured field value captured from a tracing span or event.
 ///
-/// The original values supplied to `tracing` may borrow local data, so the store owns
+/// The original values supplied to [`tracing`] may borrow local data, so the store owns
 /// all captured values. Values that do not have a more precise visitor callback are
 /// stored as [`FieldValue::Debug`].
+///
+/// `FieldValue` is intended for inspection, filtering, and display. It is not a
+/// lossless serialization of arbitrary user values.
 #[derive(Clone, Debug, PartialEq)]
 #[non_exhaustive]
 pub enum FieldValue {

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -2,14 +2,51 @@
 //!
 //! Capture-time filters decide what reaches [`crate::TraceStore`]. Display filters
 //! decide what a viewer shows from the retained records at render time.
+//!
+//! # Common Workflow
+//!
+//! Build a [`TraceFilter`] with the `with_*` methods, then pass it to
+//! [`crate::TraceViewer::set_filter`]. The filter changes which retained events are
+//! visible without changing store contents or storage counters.
+//!
+//! # Related Modules
+//!
+//! - [`crate::layer`] and [`tracing_subscriber`] filters own capture-time filtering.
+//! - [`crate::store`] retains records before display-time filtering.
+//! - [`crate::viewer`] owns the active filter for an on-screen view.
 
 use crate::record::{EventRecord, Level, SpanRecord};
 use crate::store::TraceSnapshot;
 
 /// Display-time event filter.
 ///
-/// Filters are intentionally independent from `tracing_subscriber` filters. They do
+/// Filters are intentionally independent from [`tracing_subscriber`] filters. They do
 /// not affect capture, and changing them never loses retained events.
+///
+/// Matching is substring-based for targets, text, span names, and field values.
+/// Level matching keeps events whose level is at least as severe as the configured
+/// minimum according to [`tracing`] level ordering.
+///
+/// ```
+/// use tracing::subscriber;
+/// use tracing_subscriber::{layer::SubscriberExt, Registry};
+/// use tui_tracing::{TraceFilter, TraceLayer, TraceViewer};
+///
+/// let (layer, store) = TraceLayer::new();
+/// let subscriber = Registry::default().with(layer);
+///
+/// subscriber::with_default(subscriber, || {
+///     tracing::debug!(target: "app::cache", "warming cache");
+///     tracing::warn!(target: "app::network", status = 503, "retrying request");
+/// });
+///
+/// let mut viewer = TraceViewer::new(store);
+/// viewer.set_filter(TraceFilter::all().with_min_level(tracing::Level::INFO));
+///
+/// let status = viewer.status();
+/// assert_eq!(status.visible_events, 1);
+/// assert_eq!(status.hidden_events, 1);
+/// ```
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 pub struct TraceFilter {
     min_level: Option<Level>,
@@ -26,6 +63,9 @@ impl TraceFilter {
     }
 
     /// Set the minimum visible level.
+    ///
+    /// For example, `INFO` shows `INFO`, `WARN`, and `ERROR`, but hides `DEBUG`
+    /// and `TRACE`.
     pub fn with_min_level(mut self, level: tracing::Level) -> Self {
         self.min_level = Some(level.into());
         self
@@ -38,12 +78,17 @@ impl TraceFilter {
     }
 
     /// Restrict visible events to records containing `text`.
+    ///
+    /// Text matching searches event targets, event field names and values, span
+    /// names, span targets, and span field names and values.
     pub fn with_text(mut self, text: impl Into<String>) -> Self {
         self.text = Some(text.into());
         self
     }
 
     /// Restrict visible events to records with a field containing `value`.
+    ///
+    /// The field name must match exactly. The field value is matched as text.
     pub fn with_field(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
         self.field = Some(FieldFilter {
             name: name.into(),
@@ -59,6 +104,10 @@ impl TraceFilter {
     }
 
     /// Return true when an event should be shown for the snapshot.
+    ///
+    /// This method is public so applications can reuse the same display-time
+    /// matching policy for custom views. It does not mutate the filter, event, or
+    /// snapshot.
     pub fn matches_event(&self, event: &EventRecord, snapshot: &TraceSnapshot) -> bool {
         self.matches_level(event)
             && self.matches_target(event)

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,6 +1,7 @@
-//! Formatting captured records into Ratatui text.
+//! Formatting captured records into [`ratatui`] text.
 //!
-//! This module owns the default `tracing_subscriber::fmt`-inspired presentation.
+//! This module owns the default
+//! [`tracing_subscriber::fmt`](mod@tracing_subscriber::fmt)-inspired presentation.
 //! It is deliberately event-stream oriented; span hierarchy is rendered as compact
 //! inline context.
 
@@ -14,10 +15,20 @@ use crate::store::TraceSnapshot;
 
 const OVERFLOW_MARKER: &str = "...";
 
-/// Options for rendering captured trace records.
+/// Options for rendering compact event rows.
+///
+/// These options control presentation only. They do not change capture,
+/// retention, display-time filtering, or selected-event detail content.
+///
+/// Applications can mutate this struct directly and pass it to
+/// [`crate::TraceViewer::set_format_options`], or use the viewer convenience
+/// methods for common toggles.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct FormatOptions {
     /// Timestamp format used for each compact event row.
+    ///
+    /// Defaults to [`TimestampFormat::ShortLocal`] to preserve horizontal space in
+    /// TUI panes.
     pub timestamp_format: TimestampFormat,
 
     /// Whether to render compact span context after the event target.
@@ -28,9 +39,15 @@ pub struct FormatOptions {
     pub show_span_context: bool,
 
     /// Whether to render event target before the event message.
+    ///
+    /// Defaults to `true`. Disabling it makes rows narrower but removes the most
+    /// direct module or subsystem cue.
     pub show_target: bool,
 
     /// Whether to render source file and line when present.
+    ///
+    /// Defaults to `false`. Source locations are still available in
+    /// [`crate::TraceEventDetail`] when compact rows hide them.
     pub show_location: bool,
 }
 
@@ -61,7 +78,11 @@ pub enum TimestampFormat {
     /// Custom [`chrono`] format string.
     ///
     /// Invalid format strings do not fail rendering; they are rendered according
-    /// to `chrono`'s formatting behavior.
+    /// to [`chrono`]'s formatting behavior.
+    ///
+    /// Use this when application layout has a specific timestamp convention. Keep
+    /// the resulting width in mind because compact row truncation has less room
+    /// for target, message, and fields when timestamps are long.
     Custom(String),
 }
 

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,9 +1,27 @@
-//! `tracing-subscriber` capture layer.
+//! [`tracing_subscriber`] capture layer.
 //!
 //! [`TraceLayer`] records tracing spans and events into [`crate::TraceStore`]. It
 //! intentionally does not decide what the TUI shows. Applications can combine it
-//! with ordinary `tracing_subscriber` capture filters and then apply
+//! with ordinary [`tracing_subscriber`] capture filters and then apply
 //! [`crate::TraceFilter`] at display time.
+//!
+//! # Common Workflow
+//!
+//! Call [`TraceLayer::new`] to create a layer and matching store, install the layer
+//! in a [`tracing_subscriber`] registry, keep the store in application state, and
+//! render it with [`crate::TraceViewer`].
+//!
+//! # Lifecycle And Side Effects
+//!
+//! `TraceLayer` has no background task and no drop-time cleanup. Its side effect is
+//! writing captured records into its [`crate::TraceStore`] while it is installed in
+//! the active subscriber. Installing the subscriber is an application responsibility.
+//!
+//! # Related Modules
+//!
+//! - [`crate::store`] owns the retained records written by this layer.
+//! - [`crate::viewer`] renders a store in [`ratatui`].
+//! - [`crate::filter`] applies display-time filters after capture.
 
 use tracing::{Subscriber, span};
 use tracing_subscriber::Layer;
@@ -16,6 +34,10 @@ use crate::record::{SpanId, SpanRecord};
 use crate::store::TraceStore;
 
 /// Subscriber layer that captures structured tracing records for a TUI.
+///
+/// `TraceLayer` implements [`tracing_subscriber::Layer`] and records spans and
+/// events into a [`TraceStore`]. It is cheap to construct around an existing store
+/// and does not perform I/O, spawn work, or install itself globally.
 #[derive(Debug, Default)]
 pub struct TraceLayer {
     store: TraceStore,
@@ -24,14 +46,34 @@ pub struct TraceLayer {
 impl TraceLayer {
     /// Create a layer and the store it writes into.
     ///
-    /// Install the layer in a `tracing_subscriber` registry and keep the returned
+    /// Install the layer in a [`tracing_subscriber`] registry and keep the returned
     /// store in application state for rendering.
+    ///
+    /// ```
+    /// use tracing::subscriber;
+    /// use tracing_subscriber::Registry;
+    /// use tracing_subscriber::layer::SubscriberExt;
+    /// use tui_tracing::{TraceLayer, TraceViewer};
+    ///
+    /// let (layer, store) = TraceLayer::new();
+    /// let subscriber = Registry::default().with(layer);
+    ///
+    /// subscriber::with_default(subscriber, || {
+    ///     tracing::info!("captured by TraceLayer");
+    /// });
+    ///
+    /// let mut viewer = TraceViewer::new(store);
+    /// assert_eq!(viewer.status().visible_events, 1);
+    /// ```
     pub fn new() -> (Self, TraceStore) {
         let store = TraceStore::default();
         (Self::from_store(store.clone()), store)
     }
 
     /// Create a layer that writes into an existing store.
+    ///
+    /// Use this when the application wants to choose store capacity with
+    /// [`TraceStore::with_capacity`] or share the same store across setup code.
     pub fn from_store(store: TraceStore) -> Self {
         Self { store }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,16 @@
-//! Runtime tracing viewer primitives for Ratatui applications.
+//! # tui-tracing
 //!
-//! `tui-tracing` captures native [`tracing`] spans and events into a runtime store
-//! and renders that store as a `tracing_subscriber::fmt`-style event stream inside
-//! a TUI. It is intentionally tracing-first: it does not adapt through the `log`
-//! crate, and display-time filtering is separate from subscriber capture filtering.
+//! `tui-tracing` provides a runtime store and [`ratatui`] widget for displaying
+//! [`tracing`] events inside a [`ratatui`]-based application. It captures native
+//! tracing spans and events, retains them in [`TraceStore`], and renders them as a
+//! [`tracing_subscriber::fmt`](mod@tracing_subscriber::fmt)-style event stream with
+//! [`TraceViewer`]. It is intentionally tracing-first: it does not adapt through the `log` crate,
+//! and display-time filtering is separate from subscriber capture filtering.
+//!
+//! Use this crate when an application needs tracing diagnostics available inside
+//! its own [`ratatui`] UI at runtime. The primary path is:
+//! capture with [`TraceLayer`], retain in [`TraceStore`], filter with
+//! [`TraceFilter`], and render with [`TraceViewer`].
 //!
 //! # Start Here
 //!
@@ -26,6 +33,9 @@
 //! terminal.draw(|frame| frame.render_widget(&mut viewer, frame.area())).unwrap();
 //! ```
 //!
+//! For a runnable version of this workflow, run `cargo run --example basic`. For
+//! the interactive demo, run `cargo run --example demo`.
+//!
 //! # Core Concepts
 //!
 //! - [`TraceLayer`] captures structured tracing records.
@@ -37,9 +47,40 @@
 //! - [`TraceEventDetail`] renders full detail for one selected event.
 //! - [`TimingLayer`] optionally records span busy/idle timing.
 //!
+//! # Module Map
+//!
+//! - [`layer`] owns [`tracing_subscriber`] integration.
+//! - [`store`] owns retained runtime data and storage counters.
+//! - [`viewer`] owns Ratatui rendering state.
+//! - [`filter`] owns display-time matching.
+//! - [`record`] owns captured event and span record shapes.
+//! - [`field`] owns structured field values.
+//!
 //! Span trees, timing summaries, and aggregation are secondary views built on the
-//! same stored records. The default view stays event-stream-first because that is
-//! the most common diagnostic path while an application is running.
+//! same stored records. The default view stays event-stream-first because recent
+//! event output is the diagnostic surface users already know from
+//! [`tracing_subscriber::fmt`](mod@tracing_subscriber::fmt).
+//!
+//! # Runtime And Lifecycle
+//!
+//! [`TraceLayer`] is a [`tracing_subscriber::Layer`]. It captures records only
+//! while installed in the active subscriber. [`TraceStore`] is an in-memory,
+//! cloneable handle backed by synchronization, so capture and rendering can run on
+//! different threads.
+//!
+//! [`TraceViewer`] is application state. It intentionally implements
+//! [`ratatui::widgets::Widget`] for `&mut TraceViewer` because scrollback and
+//! follow-tail state depend on the render area and can only be clamped correctly
+//! during rendering.
+//!
+//! This crate does not install a global subscriber by itself, does not spawn
+//! background tasks, and does not manage terminal raw mode. Those lifecycle
+//! concerns remain owned by the application.
+//!
+//! # Feature Flags
+//!
+//! This crate currently has no feature flags. All public APIs are available with
+//! default dependencies.
 //!
 //! # Main Screen
 //!
@@ -50,8 +91,8 @@
 //! The main screen is an event stream, not a span tree. Span nesting is important
 //! runtime context, but it should appear as compact inline context first and as
 //! full detail only when the user selects or expands an event. This keeps the
-//! common diagnostic path close to `tracing_subscriber::fmt` output while still
-//! preserving structured tracing data for richer views.
+//! common diagnostic path close to [`tracing_subscriber::fmt`](mod@tracing_subscriber::fmt) output
+//! while still preserving structured tracing data for richer views.
 //!
 //! The first visible surface should cover:
 //!
@@ -69,8 +110,8 @@
 //! ```
 //!
 //! Compact rows use [`TimestampFormat::ShortLocal`] by default because full
-//! timestamps are usually too wide for an in-app diagnostics pane. Rows prioritize
-//! level, target, message, and fields. Inline span context is available through
+//! timestamps consume width needed for target, message, and fields. Inline span
+//! context is available through
 //! [`FormatOptions`] and [`TraceViewer::set_show_span_context`], but is hidden by
 //! default so nested spans do not dominate the event stream. A row should remain
 //! useful when an event has no `message` field because field-only events are valid

--- a/src/record.rs
+++ b/src/record.rs
@@ -1,8 +1,20 @@
-//! Captured tracing records.
+//! Captured [`tracing`] records.
 //!
 //! Records are immutable snapshots of tracing activity. The capture layer writes
 //! them into [`crate::TraceStore`], while filters and widgets read cloned snapshots
 //! without holding store locks during formatting or rendering.
+//!
+//! # Common Workflow
+//!
+//! Applications receive records through [`crate::TraceStore::snapshot`],
+//! [`crate::TraceViewer::selected_event`], or [`crate::TraceViewer::selected_detail`].
+//! Use these types directly when building custom views, exports, or tests.
+//!
+//! # Related Modules
+//!
+//! - [`crate::layer`] creates records from [`tracing`] callbacks.
+//! - [`crate::store`] retains records and returns snapshots.
+//! - [`crate::viewer`] renders records into [`ratatui`] widgets.
 
 use chrono::{DateTime, Local};
 use tracing::{Metadata, span};
@@ -11,18 +23,30 @@ use crate::Timing;
 use crate::field::FieldMap;
 
 /// Stable sequence number assigned when an event is captured.
+///
+/// Event ids are monotonically increasing within one [`crate::TraceStore`]. They
+/// are not globally unique and reset when a store is created.
 pub type EventId = u64;
 
-/// Numeric tracing span identifier used inside the store.
+/// Numeric [`tracing`] span identifier used inside the store.
+///
+/// Span ids come from [`tracing`]. They are useful for relating events to retained
+/// spans inside a single snapshot.
 pub type SpanId = u64;
 
 /// A captured tracing event.
 ///
 /// Events are the primary display unit. Span hierarchy is preserved as context, but
 /// the default viewer renders an event stream rather than a tree.
+///
+/// Event records are cloned into [`crate::TraceSnapshot`] values. Mutating a cloned
+/// record does not affect the store.
 #[derive(Clone, Debug)]
 pub struct EventRecord {
     /// Monotonic store-local event sequence.
+    ///
+    /// The id is assigned before retention is applied. Evicted or dropped events
+    /// leave gaps in later snapshots.
     pub id: EventId,
 
     /// Wall-clock time at capture.
@@ -31,7 +55,10 @@ pub struct EventRecord {
     /// Event level.
     pub level: Level,
 
-    /// Event target, usually the Rust module path.
+    /// Event target from tracing metadata.
+    ///
+    /// This value comes from [`tracing`] metadata and is used by compact row
+    /// formatting and [`crate::TraceFilter::with_target`].
     pub target: String,
 
     /// Module path reported by tracing metadata.
@@ -44,6 +71,9 @@ pub struct EventRecord {
     pub line: Option<u32>,
 
     /// Structured event fields.
+    ///
+    /// The `message` field, when present, is promoted by viewer formatting but
+    /// remains in this map.
     pub fields: FieldMap,
 
     /// Innermost event span, if any.
@@ -80,9 +110,12 @@ impl EventRecord {
 /// Spans are stored for display context, filtering, lifecycle state, and optional
 /// timing. The default widget shows them inline with events and leaves tree-oriented
 /// presentation to future secondary views.
+///
+/// Span records are retained independently from the event FIFO. They are cleared
+/// only when [`crate::TraceStore::clear`] is called.
 #[derive(Clone, Debug)]
 pub struct SpanRecord {
-    /// Numeric span identifier assigned by `tracing`.
+    /// Numeric span identifier assigned by [`tracing`].
     pub id: SpanId,
 
     /// Parent span identifier, if this span was created inside another span.
@@ -92,9 +125,15 @@ pub struct SpanRecord {
     pub start_time: DateTime<Local>,
 
     /// Wall-clock time when the span closed.
+    ///
+    /// `None` means the span was still open at the time of the snapshot or the
+    /// close event had not reached the store.
     pub close_time: Option<DateTime<Local>>,
 
     /// Latest timing data recorded for the span.
+    ///
+    /// This is present only when [`crate::TimingLayer`] is installed in the same
+    /// subscriber stack before `TraceLayer` observes timing updates.
     pub timing: Option<Timing>,
 
     /// Span level.
@@ -103,7 +142,7 @@ pub struct SpanRecord {
     /// Span name.
     pub name: String,
 
-    /// Span target, usually the Rust module path.
+    /// Span target from tracing metadata.
     pub target: String,
 
     /// Module path reported by tracing metadata.
@@ -116,6 +155,9 @@ pub struct SpanRecord {
     pub line: Option<u32>,
 
     /// Structured span fields.
+    ///
+    /// These are fields recorded when the span was created. Later field updates
+    /// are not currently captured as a separate public event stream.
     pub fields: FieldMap,
 }
 
@@ -149,6 +191,10 @@ impl SpanRecord {
 }
 
 /// Tracing level captured as a small value type.
+///
+/// This wrapper preserves [`tracing`] level ordering while allowing the crate to
+/// derive traits and keep record fields simple. It converts to and from
+/// [`tracing::Level`] and displays like the wrapped level.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Ord, PartialOrd)]
 pub struct Level(pub tracing::Level);
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -1,13 +1,31 @@
 //! Runtime trace storage.
 //!
-//! [`TraceStore`] is the handoff point between the tracing subscriber layer and TUI
-//! rendering. The subscriber writes complete structured records, and the application
-//! reads snapshots later for display-time filtering.
+//! [`TraceStore`] is the handoff point between the [`tracing`] subscriber layer and
+//! TUI rendering. The subscriber writes complete structured records, and the
+//! application reads snapshots later for display-time filtering.
 //!
 //! Event retention is bounded FIFO storage. When the event buffer reaches capacity,
 //! the oldest retained event is evicted before the new event is retained. A capacity
 //! of zero drops all events at insertion time while still allowing span metadata to
 //! be recorded. These storage counters are independent of display-time filtering.
+//!
+//! # Common Workflow
+//!
+//! Create a store with [`TraceStore::default`] or [`TraceStore::with_capacity`],
+//! install a [`crate::TraceLayer`] that writes to it, and read snapshots or render a
+//! [`crate::TraceViewer`] from another clone.
+//!
+//! # Concurrency
+//!
+//! `TraceStore` is backed by a lock and is cheap to clone. Subscriber callbacks may
+//! write while the UI reads snapshots. Snapshot creation clones retained records so
+//! formatting and rendering do not hold the store lock.
+//!
+//! # Related Modules
+//!
+//! - [`crate::layer`] writes records into stores.
+//! - [`crate::filter`] matches events in snapshots.
+//! - [`crate::viewer`] renders a store and exposes view-specific status.
 
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -26,6 +44,9 @@ const DEFAULT_EVENT_CAPACITY: usize = 10_000;
 /// the TUI runtime. Events are retained in insertion order up to the configured
 /// capacity. Spans are retained while referenced by retained events or until the
 /// application explicitly clears the store.
+///
+/// `TraceStore` does not perform I/O and does not spawn background work. Dropping
+/// the final clone drops all retained records.
 #[derive(Clone, Debug)]
 pub struct TraceStore {
     inner: Arc<RwLock<TraceStoreInner>>,
@@ -41,6 +62,14 @@ impl TraceStore {
     /// Create a store retaining at most `event_capacity` events.
     ///
     /// A capacity of zero is accepted and keeps only span metadata.
+    ///
+    /// ```
+    /// use tui_tracing::TraceStore;
+    ///
+    /// let store = TraceStore::with_capacity(2);
+    /// assert_eq!(store.event_capacity(), 2);
+    /// assert!(store.status().is_empty());
+    /// ```
     pub fn with_capacity(event_capacity: usize) -> Self {
         Self {
             inner: Arc::new(RwLock::new(TraceStoreInner {
@@ -57,6 +86,10 @@ impl TraceStore {
     }
 
     /// Return a cloned snapshot of the currently retained records.
+    ///
+    /// The snapshot is point-in-time data. Concurrent capture can make it stale
+    /// immediately after it is returned, but the snapshot itself remains
+    /// internally consistent and can be rendered without holding a store lock.
     pub fn snapshot(&self) -> TraceSnapshot {
         let inner = self.inner.read();
         TraceSnapshot {
@@ -76,6 +109,10 @@ impl TraceStore {
     }
 
     /// Remove all retained events and spans and reset storage counters.
+    ///
+    /// This affects every clone of the same store. Events captured after `clear`
+    /// start new counters from zero, but event ids continue from the previous
+    /// sequence so ids remain monotonic for the lifetime of the store.
     pub fn clear(&self) {
         let mut inner = self.inner.write();
         inner.events.clear();
@@ -166,12 +203,22 @@ impl TraceStoreInner {
 }
 
 /// Cloned view of retained trace records.
+///
+/// Snapshots are immutable point-in-time data. They are intended for rendering,
+/// filtering, tests, and custom application views.
 #[derive(Clone, Debug, Default)]
 pub struct TraceSnapshot {
     /// Events retained by the store, in capture order.
+    ///
+    /// This vector contains at most [`TraceStoreStatus::event_capacity`] entries.
+    /// It may be empty either because no events have been captured, because
+    /// capacity is zero, or because the store was cleared.
     pub events: Vec<EventRecord>,
 
     /// Spans retained by the store, keyed by span identifier.
+    ///
+    /// Span records are retained for context even if no currently retained event
+    /// references them. Use [`TraceStore::clear`] to remove retained spans.
     pub spans: IndexMap<SpanId, SpanRecord>,
 
     /// Storage counters captured at the same time as the retained records.
@@ -187,24 +234,37 @@ pub struct TraceSnapshot {
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub struct TraceStoreStatus {
     /// Maximum number of events retained by this store.
+    ///
+    /// A value of zero means captured events are counted as dropped instead of
+    /// retained.
     pub event_capacity: usize,
 
     /// Number of events currently retained by this store.
+    ///
+    /// This value is always less than or equal to [`Self::event_capacity`].
     pub retained_events: usize,
 
     /// Number of spans currently retained by this store.
     pub retained_spans: usize,
 
     /// Number of events passed to this store.
+    ///
+    /// This includes retained, evicted, and dropped events.
     pub captured_events: usize,
 
     /// Number of captured events accepted into storage.
+    ///
+    /// With a nonzero capacity, accepted events may later be evicted by FIFO
+    /// retention.
     pub accepted_events: usize,
 
     /// Number of previously retained events removed because capacity was reached.
     pub evicted_events: usize,
 
     /// Number of captured events discarded before being retained.
+    ///
+    /// With the current retention policy, this only increases when capacity is
+    /// zero.
     pub dropped_events: usize,
 }
 
@@ -223,11 +283,16 @@ impl TraceStoreStatus {
     }
 
     /// Return `true` when no events are currently retained.
+    ///
+    /// An empty store may still have nonzero captured, evicted, or dropped counts.
     pub fn is_empty(self) -> bool {
         self.retained_events == 0
     }
 
     /// Return `true` when the retained event buffer has reached its configured capacity.
+    ///
+    /// This returns `true` for zero-capacity stores because retained events and
+    /// capacity are both zero.
     pub fn is_at_event_capacity(self) -> bool {
         self.retained_events == self.event_capacity
     }

--- a/src/timing_layer.rs
+++ b/src/timing_layer.rs
@@ -1,3 +1,24 @@
+//! Optional span busy/idle timing.
+//!
+//! [`TimingLayer`] records timing data into span extensions. [`crate::TraceLayer`]
+//! can then copy the latest [`Timing`] into retained [`crate::SpanRecord`] values.
+//!
+//! # Common Workflow
+//!
+//! Install `TimingLayer` in the same subscriber stack as `TraceLayer` when selected
+//! event detail should include span busy and idle durations.
+//!
+//! # Lifecycle And Side Effects
+//!
+//! The layer stores timing state in [`tracing`] span extensions. It has no background
+//! task and no drop-time cleanup. Timing stops changing once a span closes.
+//!
+//! # Related Modules
+//!
+//! - [`crate::layer`] copies timing values into retained span records.
+//! - [`crate::record`] stores optional timing data on [`crate::SpanRecord`].
+//! - [`crate::viewer`] displays timing in selected-event detail.
+
 use std::time::Duration;
 
 use quanta::Instant;
@@ -11,6 +32,28 @@ use tracing_subscriber::registry::LookupSpan;
 ///
 /// The layer stores [`Timing`] in each span's extensions. [`TraceLayer`](crate::TraceLayer)
 /// reads that extension and copies the latest timing values into retained span records.
+///
+/// `TimingLayer` should be installed alongside [`crate::TraceLayer`]. By itself it
+/// only updates span extensions; it does not retain or render anything.
+///
+/// ```
+/// use tracing::subscriber;
+/// use tracing_subscriber::Registry;
+/// use tracing_subscriber::layer::SubscriberExt;
+/// use tui_tracing::{TimingLayer, TraceLayer};
+///
+/// let (trace_layer, store) = TraceLayer::new();
+/// let subscriber = Registry::default().with(TimingLayer).with(trace_layer);
+///
+/// subscriber::with_default(subscriber, || {
+///     let span = tracing::info_span!("request");
+///     let _guard = span.enter();
+///     tracing::info!("handled request");
+/// });
+///
+/// let snapshot = store.snapshot();
+/// assert_eq!(snapshot.events.len(), 1);
+/// ```
 #[derive(Debug, Default)]
 pub struct TimingLayer;
 
@@ -18,6 +61,9 @@ pub struct TimingLayer;
 ///
 /// Busy time is accumulated while the span is entered. Idle time is accumulated
 /// while the span exists but is not currently entered.
+///
+/// Timing values are copied into [`crate::SpanRecord`] snapshots. They are cheap
+/// to copy and contain no handles back to the subscriber.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Timing {
     state: TimingState,
@@ -35,6 +81,9 @@ impl Default for Timing {
 }
 
 /// Current lifecycle state for span timing.
+///
+/// The state describes the latest known span timing lifecycle, not the
+/// application-level meaning of the span.
 #[derive(Debug, Default, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum TimingState {
     /// The span is closed.
@@ -95,6 +144,9 @@ where
 
 impl Timing {
     /// Create a timing record in the idle state.
+    ///
+    /// Applications normally do not call this directly; [`TimingLayer`] creates
+    /// timing records for new spans.
     pub fn new() -> Self {
         Self {
             state: TimingState::Idle,
@@ -110,6 +162,9 @@ impl Timing {
     ///
     /// If this is called while the span is idle, the idle time will be updated. If this is called
     /// while the span is busy, the busy time will be updated.
+    ///
+    /// This method is public for tests and custom subscriber integrations. Normal
+    /// applications should let [`TimingLayer`] call it from subscriber callbacks.
     pub fn enter(&mut self) {
         self.record();
         self.enter_count += 1;
@@ -120,6 +175,9 @@ impl Timing {
     ///
     /// If this is called while the span is busy, the busy time will be updated. If this is called
     /// while the span is idle, the idle time will be updated.
+    ///
+    /// This method is public for tests and custom subscriber integrations. Normal
+    /// applications should let [`TimingLayer`] call it from subscriber callbacks.
     pub fn exit(&mut self) {
         self.record();
         self.exit_count += 1;

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -1,8 +1,27 @@
 //! Ratatui trace viewer.
 //!
-//! [`TraceViewer`] is the high-level TUI integration point. It owns display-time
-//! state such as filters and scrollback, and renders through `impl Widget for
-//! &mut TraceViewer` so applications do not need `StatefulWidget`.
+//! [`TraceViewer`] is the high-level [`ratatui`] integration point. It owns
+//! display-time state such as filters and scrollback, and renders through
+//! `impl Widget for &mut TraceViewer` so applications do not need
+//! [`ratatui::widgets::StatefulWidget`].
+//!
+//! # Common Workflow
+//!
+//! Store a [`TraceViewer`] in application state, mutate it from input handlers, and
+//! render `&mut viewer` in the area assigned to trace output.
+//!
+//! # Lifecycle And Side Effects
+//!
+//! Rendering mutates scroll state because follow-tail and page movement depend on
+//! the [`ratatui::layout::Rect`] height. The widget does not install subscribers,
+//! write files, spawn tasks, or manage terminal state.
+//!
+//! # Related Modules
+//!
+//! - [`crate::store`] retains the records rendered by the viewer.
+//! - [`crate::filter`] owns display-time matching.
+//! - [`crate::record`] and [`crate::field`] define the data shown in rows and selected-event
+//!   detail.
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -16,10 +35,38 @@ use crate::format::{FormatOptions, event_line};
 use crate::record::{EventId, EventRecord, SpanId, SpanRecord};
 use crate::store::{TraceSnapshot, TraceStore, TraceStoreStatus};
 
-/// Event-stream trace viewer for Ratatui applications.
+/// Event-stream trace viewer for [`ratatui`] applications.
 ///
 /// The viewer does not install tracing subscribers and does not own capture policy.
 /// It renders retained records from a [`TraceStore`] using display-time filters.
+///
+/// `TraceViewer` is cheap to clone, but clones have independent filter, scroll,
+/// formatting, and selection state. Clones share the same underlying store.
+///
+/// ```
+/// use ratatui::Terminal;
+/// use ratatui::backend::TestBackend;
+/// use tracing::subscriber;
+/// use tracing_subscriber::Registry;
+/// use tracing_subscriber::layer::SubscriberExt;
+/// use tui_tracing::{TraceLayer, TraceViewer};
+///
+/// let (layer, store) = TraceLayer::new();
+/// let subscriber = Registry::default().with(layer);
+///
+/// subscriber::with_default(subscriber, || {
+///     tracing::info!("ready");
+/// });
+///
+/// let mut viewer = TraceViewer::new(store);
+/// let backend = TestBackend::new(80, 3);
+/// let mut terminal = Terminal::new(backend).unwrap();
+/// terminal
+///     .draw(|frame| frame.render_widget(&mut viewer, frame.area()))
+///     .unwrap();
+///
+/// assert_eq!(viewer.status().visible_events, 1);
+/// ```
 #[derive(Clone, Debug)]
 pub struct TraceViewer {
     store: TraceStore,
@@ -34,6 +81,18 @@ pub struct TraceViewer {
 
 impl TraceViewer {
     /// Create a viewer for the given store.
+    ///
+    /// New viewers follow the tail, show all retained events, use compact default
+    /// formatting, and have no selected event.
+    ///
+    /// ```
+    /// use tui_tracing::{TraceStore, TraceViewer};
+    ///
+    /// let store = TraceStore::default();
+    /// let viewer = TraceViewer::new(store);
+    ///
+    /// assert_eq!(viewer.status().visible_events, 0);
+    /// ```
     pub fn new(store: TraceStore) -> Self {
         Self {
             store,
@@ -58,6 +117,9 @@ impl TraceViewer {
     }
 
     /// Replace the display-time filter.
+    ///
+    /// This does not change retained records. If the current selection is no
+    /// longer visible through the new filter, selection is cleared.
     pub fn set_filter(&mut self, filter: TraceFilter) {
         self.filter = filter;
         self.clamp_selection();
@@ -74,6 +136,9 @@ impl TraceViewer {
     }
 
     /// Return the selected retained event if it is still visible.
+    ///
+    /// The returned event is cloned from a fresh store snapshot. It may be stale
+    /// immediately if capture continues concurrently.
     pub fn selected_event(&self) -> Option<EventRecord> {
         let snapshot = self.store.snapshot();
         self.selected_event_for_snapshot(&snapshot).cloned()
@@ -92,12 +157,16 @@ impl TraceViewer {
     }
 
     /// Select the first visible event if there is one.
+    ///
+    /// "First" means oldest in the filtered event stream.
     pub fn select_first(&mut self) {
         let snapshot = self.store.snapshot();
         self.selected_event_id = self.visible_events(&snapshot).first().map(|event| event.id);
     }
 
     /// Select the last visible event if there is one.
+    ///
+    /// "Last" means newest in the filtered event stream.
     pub fn select_last(&mut self) {
         let snapshot = self.store.snapshot();
         self.selected_event_id = self.visible_events(&snapshot).last().map(|event| event.id);
@@ -133,6 +202,9 @@ impl TraceViewer {
     }
 
     /// Replace the formatting options.
+    ///
+    /// Formatting options affect compact event rows only. They do not change
+    /// capture, filtering, selection, or selected-event detail content.
     pub fn set_format_options(&mut self, format: FormatOptions) {
         self.format = format;
     }
@@ -196,6 +268,9 @@ impl TraceViewer {
     }
 
     /// Scroll older by `lines`.
+    ///
+    /// Calling this leaves follow-tail mode. The final scroll offset is clamped
+    /// during the next render, when the viewer knows the current viewport height.
     pub fn scroll_up(&mut self, lines: u16) {
         if self.follow_tail {
             self.scroll_top = self.last_tail_scroll;
@@ -205,6 +280,9 @@ impl TraceViewer {
     }
 
     /// Scroll newer by `lines`, returning to follow mode at the bottom.
+    ///
+    /// The bottom is based on the most recently rendered viewport. If no render
+    /// has happened yet, the stored tail offset is zero.
     pub fn scroll_down(&mut self, lines: u16) {
         let next_scroll = self.scroll_top.saturating_add(lines);
         if next_scroll >= self.last_tail_scroll {
@@ -402,6 +480,31 @@ impl Widget for &mut TraceViewer {
 /// A detail value is an owned snapshot of the selected event and its span stack.
 /// It is separate from compact row rendering so applications can choose whether to
 /// show details in a bottom pane, side pane, popup, or another app-owned surface.
+///
+/// `TraceEventDetail` is independent from the store after construction. Rendering
+/// it does not mutate viewer state.
+///
+/// ```
+/// use tracing::subscriber;
+/// use tracing_subscriber::Registry;
+/// use tracing_subscriber::layer::SubscriberExt;
+/// use tui_tracing::{TraceLayer, TraceViewer};
+///
+/// let (layer, store) = TraceLayer::new();
+/// let subscriber = Registry::default().with(layer);
+///
+/// subscriber::with_default(subscriber, || {
+///     tracing::warn!(code = 503, "retrying request");
+/// });
+///
+/// let mut viewer = TraceViewer::new(store);
+/// viewer.select_first();
+///
+/// let detail = viewer.selected_detail().expect("selected event has detail");
+/// let text = detail.text().to_string();
+/// assert!(text.contains("retrying request"));
+/// assert!(text.contains("code"));
+/// ```
 #[derive(Clone, Debug)]
 pub struct TraceEventDetail {
     event: EventRecord,
@@ -410,6 +513,9 @@ pub struct TraceEventDetail {
 
 impl TraceEventDetail {
     /// Create event detail from an event and already-resolved span stack.
+    ///
+    /// Most applications should call [`TraceViewer::selected_detail`] instead so
+    /// the span stack is resolved from one store snapshot.
     pub fn new(event: EventRecord, span_stack: Vec<TraceSpanDetail>) -> Self {
         Self { event, span_stack }
     }
@@ -440,7 +546,7 @@ impl TraceEventDetail {
         Self::new(event.clone(), span_stack)
     }
 
-    /// Format this detail as Ratatui text.
+    /// Format this detail as [`ratatui::text::Text`].
     ///
     /// This is useful when callers need app-owned chrome or scrolling around the
     /// library's detail content. Rendering `&TraceEventDetail` directly uses the
@@ -480,6 +586,10 @@ impl Widget for &TraceEventDetail {
 ///
 /// A span detail always keeps the referenced span id. The full span record is
 /// present when it was retained in the same snapshot as the event.
+///
+/// Missing span records are expected when a detail is synthesized by an
+/// application or when future retention policies keep events without the full span
+/// metadata they reference.
 #[derive(Clone, Debug)]
 pub struct TraceSpanDetail {
     id: SpanId,
@@ -805,9 +915,15 @@ pub enum TraceScrollMode {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TraceViewStatus {
     /// Current scroll behavior.
+    ///
+    /// Applications can show this directly in a status bar or use it to decide
+    /// whether new events should be visually emphasized.
     pub scroll_mode: TraceScrollMode,
 
     /// First visible row offset from the top of the filtered event stream.
+    ///
+    /// This is updated during rendering and is measured in rendered rows, not
+    /// event ids.
     pub scroll_top: u16,
 
     /// Last computed tail offset for the filtered event stream.
@@ -817,18 +933,30 @@ pub struct TraceViewStatus {
     pub tail_scroll: u16,
 
     /// Number of retained events accepted by the active display filter.
+    ///
+    /// This is computed from a fresh store snapshot when status is requested.
     pub visible_events: usize,
 
     /// Number of retained events hidden by the active display filter.
+    ///
+    /// This does not include events evicted or dropped by store retention.
     pub hidden_events: usize,
 
     /// Selected event position in the filtered visible event stream.
+    ///
+    /// The value is zero-based. `None` means no selected event is currently
+    /// visible.
     pub selected_visible_index: Option<usize>,
 
     /// Selected event identifier, if the selected event is still visible.
+    ///
+    /// This can be `None` even when the viewer has visible events.
     pub selected_event_id: Option<EventId>,
 
     /// Active display filter.
+    ///
+    /// This clone lets applications show filter state without borrowing the
+    /// viewer.
     pub filter: TraceFilter,
 
     /// Storage status for retained records and storage-level event loss.


### PR DESCRIPTION
## Summary

- expand crate, module, type, field, and method rustdocs for the public API
- add a basic runnable example showing TraceLayer, TraceStore, TraceFilter, and TraceViewer together
- tighten README positioning and add external crate/API links
- add a docs.rs-style just recipe and include it in `just ci`

## Validation

- `cargo test --workspace --all-features`
- `cargo test --doc --workspace --all-features`
- `cargo test --examples --workspace --all-features`
- `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo +nightly docs-rs`
- `markdownlint-cli2 "docs/**/*.md" README.md CHANGELOG.md`
- `cargo +nightly fmt --all -- --check`