### PR TITLE
Enable auto-merge gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,3 +75,28 @@ jobs:
       - run: cargo audit
       - run: cargo machete
       - run: cargo minimal-versions check --direct --workspace --all-targets --all-features
+
+  required:
+    runs-on: ubuntu-24.04
+    needs:
+      - fmt
+      - clippy
+      - test
+      - doc
+      - markdown
+      - package
+      - dependency-policy
+    if: ${{ always() }}
+    steps:
+      - name: Check required jobs
+        env:
+          NEEDS_JSON: ${{ toJson(needs) }}
+          HAS_FAILED_JOB: >-
+            ${{
+              contains(needs.*.result, 'failure')
+              || contains(needs.*.result, 'cancelled')
+              || contains(needs.*.result, 'skipped')
+            }}
+        run: |
+          echo "$NEEDS_JSON"
+          test "$HAS_FAILED_JOB" = "false"


### PR DESCRIPTION
## Summary
- add a single aggregate required CI job for repository branch rulesets
- enable repository auto-merge and activate the default ruleset with required as the only required status check

## Validation
- cargo +nightly fmt --all -- --check
- just ci