### PR TITLE
Add cargo-deny policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,8 +71,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-audit,cargo-hack,cargo-machete,cargo-minimal-versions
+          tool: cargo-audit,cargo-deny,cargo-hack,cargo-machete,cargo-minimal-versions
       - run: cargo audit
+      - run: cargo deny check
       - run: cargo machete
       - run: cargo minimal-versions check --direct --workspace --all-targets --all-features
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,26 @@
+[advisories]
+ignore = []
+
+[licenses]
+allow = [
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "MIT",
+    "Unicode-3.0",
+    "Zlib",
+]
+confidence-threshold = 0.8
+exceptions = []
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -19,12 +19,6 @@ This crate is experimental, but releases should still use a repeatable quality g
    just ci
    ```
 
-1. Run the pending dependency-policy check once `cargo-deny` is configured:
-
-   ```sh
-   cargo deny check
-   ```
-
 1. Validate package contents if you need to inspect the archive before publishing:
 
    ```sh
@@ -73,6 +67,5 @@ This crate is experimental, but releases should still use a repeatable quality g
 ## Manual Validation Gaps
 
 - Platform support is not yet validated on Windows, macOS, and Linux CI.
-- No `cargo-deny` policy is configured yet.
 - No fuzz targets or benchmarks exist yet.
 - Markdown link checking is not configured because external link checks can be flaky.

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -122,7 +122,7 @@ easy to understand, audit, extend, and use correctly.
 - `cargo package --workspace --allow-dirty` for local pre-commit validation
 - `cargo audit`
 - `cargo machete`
-- `cargo deny check`, once dependency, license, and advisory policy is configured
+- `cargo deny check`
 - `cargo udeps`, periodically if nightly is acceptable
 - Markdown linting for README, docs, changelog, and contribution docs
 - Spell checking for public docs if the project has enough documentation to justify it

--- a/justfile
+++ b/justfile
@@ -34,13 +34,16 @@ package:
 audit:
     cargo audit
 
+deny:
+    cargo deny check
+
 machete:
     cargo machete
 
 minimal-versions:
     cargo minimal-versions check --direct --workspace --all-targets --all-features
 
-ci: fmt-check check test clippy doc docs-rs markdown package audit machete minimal-versions
+ci: fmt-check check test clippy doc docs-rs markdown package audit deny machete minimal-versions
 
 demo-gif:
     mkdir -p target/vhs


### PR DESCRIPTION
## Summary

- add an explicit cargo-deny policy for advisories, licenses, duplicate crates, and dependency sources
- run cargo deny check in the dependency-policy CI job and local just ci gate
- update release and standards docs now that cargo-deny is configured

Closes #20

## Validation

- cargo deny check
- just deny
- markdownlint-cli2 docs/standards.md docs/release-checklist.md