### PR TITLE
Improve new-user onboarding docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,77 @@ so a running TUI can inspect more information than it currently displays.
 
 Status: experimental pre-release API.
 
+## Quick Start
+
+Add the crate, install the tracing layer once, keep the viewer in app state, and render it like a
+normal Ratatui widget:
+
+```sh
+cargo add tui-tracing ratatui tracing tracing-subscriber
+```
+
+```rust
+use ratatui::DefaultTerminal;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+use tui_tracing::{TraceLayer, TraceViewer};
+
+fn main() -> std::io::Result<()> {
+    let (layer, store) = TraceLayer::new();
+    tracing_subscriber::registry().with(layer).init();
+
+    let mut app = App {
+        traces: TraceViewer::new(store),
+    };
+    ratatui::run(|terminal| app.run(terminal))
+}
+
+struct App {
+    traces: TraceViewer,
+}
+
+impl App {
+    fn run(&mut self, terminal: &mut DefaultTerminal) -> std::io::Result<()> {
+        tracing::info!(target: "demo", peer = "alpha", "connected");
+        terminal.draw(|frame| frame.render_widget(&mut self.traces, frame.area()))?;
+        Ok(())
+    }
+}
+```
+
+Run the small application-style example with:
+
+```sh
+cargo run --example basic
+```
+
+The `basic` example uses the Ratatui 0.30 `ratatui::run` lifecycle, emits periodic tracing events,
+and wires a few keys to filtering and scrollback. The fuller `demo` example is intentionally more
+visual because it also feeds the README GIF.
+
 Licensed under either of:
 
 - Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE))
 - MIT license ([LICENSE-MIT](LICENSE-MIT))
 
 at your option.
+
+## Compared To Log Viewers
+
+Use `tui-tracing` when your application already uses [`tracing`] or wants structured runtime
+diagnostics in its own UI. The crate captures native spans, events, fields, targets, source
+locations, and span context through [`tracing-subscriber`].
+
+This is different from crates that display plain `log` records. `tui-tracing` does not adapt
+through the `log` crate and does not install a subscriber for you. It also does not replace normal
+file or stdout logging: applications can install `TraceLayer` beside a regular
+[`tracing_subscriber::fmt`] layer when they want both an in-app view and durable logs.
+
+## Compatibility
+
+- MSRV: Rust 1.88.
+- Ratatui: 0.30.
+- Backend: the library API is a Ratatui widget. The examples use crossterm through Ratatui's
+  `ratatui::run` helper.
 
 ## Design Direction
 
@@ -64,10 +129,10 @@ an event with [`TraceFilter`] does not change the captured, evicted, or dropped 
 status also has helpers for common status-bar decisions such as empty state, remaining event
 capacity, capacity pressure, and whether any captured event has been lost.
 
-## Basic Usage
+## Application Wiring
 
 ```rust
-use ratatui::{backend::TestBackend, Terminal};
+use ratatui::DefaultTerminal;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use tui_tracing::{TraceFilter, TraceLayer, TraceViewer};
 
@@ -79,11 +144,10 @@ viewer.set_filter(TraceFilter::all().with_min_level(tracing::Level::INFO));
 
 tracing::info!(target: "demo", peer = "alpha", "connected");
 
-let backend = TestBackend::new(80, 4);
-let mut terminal = Terminal::new(backend).unwrap();
-terminal
-    .draw(|frame| frame.render_widget(&mut viewer, frame.area()))
-    .unwrap();
+fn render(terminal: &mut DefaultTerminal, viewer: &mut TraceViewer) -> std::io::Result<()> {
+    terminal.draw(|frame| frame.render_widget(viewer, frame.area()))?;
+    Ok(())
+}
 ```
 
 [`TraceViewer`] intentionally implements [`Widget`] for `&mut TraceViewer`. The viewer must update

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,38 +1,166 @@
-use ratatui::Terminal;
-use ratatui::backend::TestBackend;
-use tracing::subscriber;
-use tracing_subscriber::Registry;
+use std::time::{Duration, Instant};
+
+use crossterm::event::{self, Event, KeyCode};
+use ratatui::DefaultTerminal;
+use ratatui::layout::{Constraint, Layout};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::Line;
+use ratatui::widgets::Paragraph;
+use tracing::{Level, debug, error, info, warn};
 use tracing_subscriber::layer::SubscriberExt;
-use tui_tracing::{TraceFilter, TraceLayer, TraceViewer};
+use tracing_subscriber::util::SubscriberInitExt;
+use tui_tracing::{TraceFilter, TraceLayer, TraceScrollMode, TraceViewer};
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> std::io::Result<()> {
     let (layer, store) = TraceLayer::new();
-    let subscriber = Registry::default().with(layer);
+    tracing_subscriber::registry().with(layer).init();
 
-    subscriber::with_default(subscriber, || {
-        let span = tracing::info_span!("startup", component = "example");
-        let _guard = span.enter();
-        tracing::info!(ready = true, "application ready");
-        tracing::debug!(cache_entries = 3, "cache warmed");
-    });
+    let app = App::new(TraceViewer::new(store));
+    ratatui::run(|terminal| app.run(terminal))
+}
 
-    let mut viewer = TraceViewer::new(store);
-    viewer.set_filter(TraceFilter::all().with_min_level(tracing::Level::INFO));
+struct App {
+    viewer: TraceViewer,
+    min_level: Option<Level>,
+    tick: u64,
+}
 
-    let backend = TestBackend::new(100, 4);
-    let mut terminal = Terminal::new(backend)?;
-    terminal.draw(|frame| frame.render_widget(&mut viewer, frame.area()))?;
-
-    let buffer = terminal.backend().buffer();
-    let area = buffer.area;
-    for y in area.y..area.y + area.height {
-        for x in area.x..area.x + area.width {
-            if let Some(cell) = buffer.cell((x, y)) {
-                print!("{}", cell.symbol());
-            }
+impl App {
+    fn new(mut viewer: TraceViewer) -> Self {
+        viewer.set_filter(TraceFilter::all().with_min_level(Level::INFO));
+        Self {
+            viewer,
+            min_level: Some(Level::INFO),
+            tick: 0,
         }
-        println!();
     }
 
-    Ok(())
+    fn run(mut self, terminal: &mut DefaultTerminal) -> std::io::Result<()> {
+        info!("started example application");
+        let mut next_tick = Instant::now();
+
+        loop {
+            terminal.draw(|frame| self.render(frame))?;
+
+            let timeout = next_tick.saturating_duration_since(Instant::now());
+            if event::poll(timeout)? && self.handle_event(event::read()?) {
+                break;
+            }
+
+            if Instant::now() >= next_tick {
+                self.emit_work();
+                next_tick = Instant::now() + Duration::from_millis(700);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn render(&mut self, frame: &mut ratatui::Frame<'_>) {
+        let [trace_area, status_area] =
+            Layout::vertical([Constraint::Min(0), Constraint::Length(1)]).areas(frame.area());
+
+        frame.render_widget(&mut self.viewer, trace_area);
+
+        let status = self.status_line().style(
+            Style::default()
+                .fg(Color::White)
+                .bg(Color::Blue)
+                .add_modifier(Modifier::BOLD),
+        );
+        frame.render_widget(Paragraph::new(status), status_area);
+    }
+
+    fn status_line(&self) -> Line<'static> {
+        let status = self.viewer.status();
+        let level = self
+            .min_level
+            .map(|level| format!("{level}+"))
+            .unwrap_or_else(|| "all".to_owned());
+        let mode = match status.scroll_mode {
+            TraceScrollMode::FollowTail => "tail",
+            TraceScrollMode::Scrollback => "scrollback",
+        };
+
+        Line::from(format!(
+            "q quit | l level | Up/Down scroll | End tail | level {level} | {mode} | visible {}/{}",
+            status.visible_events, status.store.retained_events
+        ))
+    }
+
+    fn handle_event(&mut self, event: Event) -> bool {
+        let Event::Key(key) = event else {
+            return false;
+        };
+
+        match key.code {
+            KeyCode::Char('q') | KeyCode::Esc => true,
+            KeyCode::Char('l') => {
+                self.cycle_level();
+                false
+            }
+            KeyCode::Up => {
+                self.viewer.scroll_up(1);
+                false
+            }
+            KeyCode::Down => {
+                self.viewer.scroll_down(1);
+                false
+            }
+            KeyCode::PageUp => {
+                self.viewer.page_up();
+                false
+            }
+            KeyCode::PageDown => {
+                self.viewer.page_down();
+                false
+            }
+            KeyCode::End => {
+                self.viewer.jump_to_newest();
+                false
+            }
+            _ => {
+                debug!(?key, "ignored key");
+                false
+            }
+        }
+    }
+
+    fn cycle_level(&mut self) {
+        self.min_level = match self.min_level {
+            None => Some(Level::ERROR),
+            Some(Level::ERROR) => Some(Level::WARN),
+            Some(Level::WARN) => Some(Level::INFO),
+            Some(Level::INFO) => Some(Level::DEBUG),
+            Some(Level::DEBUG) => None,
+            Some(Level::TRACE) => Some(Level::ERROR),
+        };
+
+        let filter = self
+            .min_level
+            .map(|level| TraceFilter::all().with_min_level(level))
+            .unwrap_or_else(TraceFilter::all);
+        self.viewer.set_filter(filter);
+
+        if let Some(level) = self.min_level {
+            info!(%level, "changed display filter");
+        } else {
+            info!("cleared display filter");
+        }
+    }
+
+    fn emit_work(&mut self) {
+        self.tick += 1;
+        let span = tracing::info_span!("sync_worker", tick = self.tick);
+        let _guard = span.enter();
+
+        match self.tick % 8 {
+            0 => error!(target: "example::sync", retry = true, "failed to sync account"),
+            3 | 6 => warn!(target: "example::sync", latency_ms = 850, "sync is slow"),
+            even if even % 2 == 0 => {
+                debug!(target: "example::cache", entries = self.tick * 4, "updated cache")
+            }
+            _ => info!(target: "example::sync", records = 12, "synced account"),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,27 +14,49 @@
 //!
 //! # Start Here
 //!
-//! Install [`TraceLayer`] in your subscriber, keep the returned [`TraceStore`] in
-//! application state, and render a [`TraceViewer`] in your UI.
+//! Install [`TraceLayer`] in your subscriber, keep a [`TraceViewer`] in application
+//! state, and render it in the area where your application wants trace output.
 //!
 //! ```
-//! use ratatui::{backend::TestBackend, Terminal};
+//! use ratatui::DefaultTerminal;
 //! use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 //! use tui_tracing::{TraceLayer, TraceViewer};
 //!
 //! let (layer, store) = TraceLayer::new();
 //! let _ = tracing_subscriber::registry().with(layer).try_init();
 //!
-//! tracing::info!(target: "demo", answer = 42, "ready");
-//!
 //! let mut viewer = TraceViewer::new(store);
-//! let backend = TestBackend::new(80, 4);
-//! let mut terminal = Terminal::new(backend).unwrap();
-//! terminal.draw(|frame| frame.render_widget(&mut viewer, frame.area())).unwrap();
+//!
+//! fn render(terminal: &mut DefaultTerminal, viewer: &mut TraceViewer) -> std::io::Result<()> {
+//!     terminal.draw(|frame| frame.render_widget(viewer, frame.area()))?;
+//!     Ok(())
+//! }
+//!
+//! tracing::info!(target: "demo", answer = 42, "ready");
 //! ```
 //!
-//! For a runnable version of this workflow, run `cargo run --example basic`. For
-//! the interactive demo, run `cargo run --example demo`.
+//! For a runnable application-style version of this workflow, run
+//! `cargo run --example basic`. For the visual demo used by the README GIF, run
+//! `cargo run --example demo`.
+//!
+//! # When To Use It
+//!
+//! Use this crate when your application already uses [`tracing`] or wants
+//! structured runtime diagnostics in its own [`ratatui`] UI. `tui-tracing` captures
+//! native spans, events, fields, targets, source locations, and span context through
+//! [`tracing_subscriber`].
+//!
+//! This is not a `log` compatibility viewer and does not install a subscriber for
+//! you. It can be installed beside a normal
+//! [`tracing_subscriber::fmt`](mod@tracing_subscriber::fmt) layer when an
+//! application wants both an in-app trace view and ordinary file or stdout logs.
+//!
+//! # Compatibility
+//!
+//! - MSRV: Rust 1.88.
+//! - Ratatui: 0.30.
+//! - Backend: the public API is a Ratatui widget. The examples use crossterm through Ratatui's
+//!   `ratatui::run` helper.
 //!
 //! # Core Concepts
 //!


### PR DESCRIPTION
## Summary

- Reframe README and crate-level docs around quick application wiring.
- Replace the basic example with a small Ratatui 0.30 `ratatui::run` app that emits events and supports filtering/scrolling.
- Add comparison and compatibility notes for new users evaluating the crate.

## Validation

- `just fmt`
- `markdownlint-cli2 README.md`
- `cargo check --examples`
- `cargo test`

Follow-up tracking:

- #25 for retention policy design and docs
- #53 for decoupling library backend features from crossterm examples
