### PR TITLE
Decouple crossterm backend feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ indexmap = "2.7"
 itertools = "0.14"
 parking_lot = "0.12"
 quanta = "0.12"
-ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
+ratatui = { version = "0.30", default-features = false }
 tracing = "0.1.12"
 tracing-subscriber = "0.3"
 
@@ -29,6 +29,7 @@ color-eyre = "0.6"
 crossterm = { version = "0.29", features = ["event-stream"] }
 futures = "0.3"
 rand = "0.10"
+ratatui = { version = "0.30", default-features = false, features = ["crossterm"] }
 tokio = { version = "1.21", features = [
     "rt-multi-thread",
     "macros",


### PR DESCRIPTION
## Summary

- Remove Ratatui's `crossterm` backend feature from the library dependency.
- Re-enable Ratatui's `crossterm` feature only for dev/example builds.
- Keep examples compiling while allowing library consumers to choose their own Ratatui backend features.

## Validation

- `cargo check --lib`
- `cargo check --examples`
- `cargo test --lib`
- `cargo tree --no-dev-dependencies -e features -i ratatui`

Refs #53.

Note: the README/crate compatibility wording mentioned in #53 is in #54, so this branch stays narrowly based on `main` and avoids a docs conflict.
