### PR TITLE
Use VHS-hosted README demo GIF

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 `tui-tracing` is a runtime store and widget for displaying [`tracing`] events inside
 [`ratatui`]-based applications.
 
-![tui-tracing demo](https://github.com/joshka/tui-tracing/releases/latest/download/tui-tracing-demo.gif)
+![tui-tracing demo](https://vhs.charm.sh/vhs-36dyKlTisqFpgEBDmaioC.gif)
 
 It is inspired by `tui-logger`, but it does not treat tracing as log compatibility glue. The
 crate captures spans, events, fields, timing, and span context directly from [`tracing-subscriber`]


### PR DESCRIPTION
## Summary

- Publish the demo GIF with `vhs publish`.
- Point the README image at the VHS-hosted URL instead of the GitHub release download URL, which is less reliable from crates.io.

Published GIF:

https://vhs.charm.sh/vhs-36dyKlTisqFpgEBDmaioC.gif

## Validation

- `just demo-gif`
- `vhs publish target/vhs/tui-tracing-demo.gif`
- `markdownlint-cli2 README.md`
