### PR TITLE
Use VHS-hosted README demo GIF

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 `tui-tracing` is a runtime store and widget for displaying [`tracing`] events inside
 [`ratatui`]-based applications.
 
-![tui-tracing demo](https://github.com/joshka/tui-tracing/releases/latest/download/tui-tracing-demo.gif)
+![tui-tracing demo](https://vhs.charm.sh/vhs-36dyKlTisqFpgEBDmaioC.gif)
 
 It is inspired by `tui-logger`, but it does not treat tracing as log compatibility glue. The
 crate captures spans, events, fields, timing, and span context directly from [`tracing-subscriber`]


### PR DESCRIPTION
## Summary

- Point the README image at the VHS-hosted demo GIF instead of the GitHub release download URL.
- Replaces the stacked #56 change with a fresh `main`-based PR so the README update can make the next release.

Published GIF:

https://vhs.charm.sh/vhs-36dyKlTisqFpgEBDmaioC.gif

## Validation

- `markdownlint-cli2 README.md`
