### PR TITLE
Fix release-plz PR CI trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,11 +42,18 @@ jobs:
       group: release-plz-${{ github.ref }}
       cancel-in-progress: false
     steps:
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v2
+        id: app-token
+        with:
+          app-id: ${{ secrets.RELEASE_PLZ_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLZ_APP_PRIVATE_KEY }}
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false
+          token: ${{ steps.app-token.outputs.token }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
@@ -54,4 +61,4 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

- Generate a GitHub App token for the release-plz PR job.
- Use that token for checkout and `release-plz release-pr` so release PR branch pushes trigger normal CI.
- Leave the trusted-publishing release job on the existing `GITHUB_TOKEN`/OIDC path.

## Context

release-plz PRs created with the default `GITHUB_TOKEN` do not trigger pull request CI, which leaves the required `required` check missing and blocks auto-merge. This follows the release-plz token guidance:

https://release-plz.dev/docs/github/token

Expected secrets:

- `RELEASE_PLZ_APP_ID`
- `RELEASE_PLZ_APP_PRIVATE_KEY`

## Validation

- Parsed `.github/workflows/release.yml` as YAML locally.
