### PR TITLE
Improve docs landing pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@
 
 ![tui-tracing demo](https://vhs.charm.sh/vhs-36dyKlTisqFpgEBDmaioC.gif)
 
-It is inspired by `tui-logger`, but it does not treat tracing as log compatibility glue. The
-crate captures spans, events, fields, timing, and span context directly from [`tracing-subscriber`]
-so a running TUI can inspect more information than it currently displays.
+Its subscriber layer captures spans, events, fields, timing, and span context so a running TUI can
+inspect structured trace data without leaving the terminal UI.
 
 Status: experimental pre-release API.
 
@@ -63,7 +62,38 @@ cargo run --example basic
 ```
 
 The `basic` example emits periodic tracing events and wires a few keys to filtering and scrollback.
-The fuller `demo` example is intentionally more visual because it also feeds the README GIF.
+The fuller `demo` example is more visual because it also feeds the README GIF.
+
+## Relationship To tui-logger
+
+`tui-tracing` is inspired by [`tui-logger`], which is a mature Ratatui log viewer with `log`,
+`slog`, and [`tracing_subscriber::Layer`] support. `tui-logger` is the better fit when an
+application wants an established logging console with target-level controls, capture-level
+controls, environment-filter integration, file logging, custom formatters, and a target selector
+widget.
+
+This crate is narrower. It focuses on making native [`tracing`] output feel like the default
+[`tracing_subscriber::fmt`] event stream inside a Ratatui application: timestamp, level, target,
+message, structured fields, and optional span context.
+
+Use `tui-tracing` when the important part is the structured tracing data and a compact fmt-like
+event stream. Use `tui-logger` when the important part is a full logging widget with built-in
+target and level management across logging backends.
+
+## Compatibility
+
+- MSRV: Rust 1.88.
+- Ratatui: 0.30.
+- Backend: the library API is a Ratatui widget. The examples use crossterm through Ratatui's
+  `ratatui::run` helper.
+
+## More Documentation
+
+- [API documentation](https://docs.rs/tui-tracing/latest/tui_tracing/) explains the runtime model,
+  viewer state, filtering, retention, event rows, and current limitations.
+- [Architecture overview](docs/architecture.md) describes where behavior belongs in the crate.
+- [Roadmap](https://github.com/joshka/tui-tracing/issues/22) tracks planned viewer affordances such
+  as aggregation and secondary views.
 
 ## License
 
@@ -74,152 +104,8 @@ Licensed under either of:
 
 at your option.
 
-## Compared To Log Viewers
-
-Use `tui-tracing` when your application already uses [`tracing`] or wants structured runtime
-diagnostics in its own UI. The crate captures native spans, events, fields, targets, source
-locations, and span context through [`tracing-subscriber`].
-
-This is different from crates that display plain `log` records. `tui-tracing` does not adapt
-through the `log` crate and does not install a subscriber for you. It also does not replace normal
-file or stdout logging: applications can install `TraceLayer` beside a regular
-[`tracing_subscriber::fmt`] layer when they want both an in-app view and durable logs.
-
-## Compatibility
-
-- MSRV: Rust 1.88.
-- Ratatui: 0.30.
-- Backend: the library API is a Ratatui widget. The examples use crossterm through Ratatui's
-  `ratatui::run` helper.
-
-## Design Direction
-
-The default viewer is event-stream-first. It should feel familiar to users of the
-[`tracing_subscriber::fmt`] formatter: colored levels, readable timestamps, messages, structured
-fields, and optional compact span context.
-
-Compact rows default to a short local timestamp so they fit inside an application pane:
-
-```text
-12:04:31.123 INFO  app::net: connected latency_ms=12
-```
-
-Compact rows hide span context by default so target, message, and fields stay readable.
-Applications can enable span context with `TraceViewer::set_show_span_context` or `FormatOptions`
-when inline span names are worth the width. When target, optional span context, message, or fields
-exceed the rendered width, compact rows use `...` to mark overflow. Span context truncates from the
-left so the innermost span remains visible when possible. The selected-event detail remains
-complete.
-
-Selected-event detail keeps the complete timestamp, target, module path, source location, promoted
-message, event fields, span stack, span fields, lifecycle state, and timing data. Its layout and
-styling should communicate ownership: event fields are nested under the event, span fields are
-nested under their span, and the span stack is context for the selected event.
-
-Span trees, timing summaries, and aggregation are secondary views built from the same retained
-records. Nesting is important data, but it should not dominate the first diagnostic view.
-
-## Runtime Model
-
-`tui-tracing` separates capture from display:
-
-1. [`TraceLayer`] captures structured tracing records into [`TraceStore`].
-1. The application keeps the store in runtime state.
-1. [`TraceViewer`] renders retained records in a [`ratatui`] widget.
-1. [`TraceFilter`] changes what is shown without losing captured data.
-
-Capture-time filtering is still useful for cost control. Display-time filtering is the main
-interaction model for diagnostics inside a running TUI.
-
-[`TraceStore::status`] exposes cheap storage counters for status bars and diagnostics: configured
-capacity, retained events, retained spans, captured events, accepted events, evicted events, and
-dropped events. These counters describe storage behavior before display-time filtering, so hiding
-an event with [`TraceFilter`] does not change the captured, evicted, or dropped totals. The returned
-status also has helpers for common status-bar decisions such as empty state, remaining event
-capacity, capacity pressure, and whether any captured event has been lost.
-
-## Application Wiring
-
-```rust
-use ratatui::DefaultTerminal;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-use tui_tracing::{TraceFilter, TraceLayer, TraceViewer};
-
-let (layer, store) = TraceLayer::new();
-tracing_subscriber::registry().with(layer).init();
-
-let mut viewer = TraceViewer::new(store);
-viewer.set_filter(TraceFilter::all().with_min_level(tracing::Level::INFO));
-
-tracing::info!(target: "demo", peer = "alpha", "connected");
-
-fn render(terminal: &mut DefaultTerminal, viewer: &mut TraceViewer) -> std::io::Result<()> {
-    terminal.draw(|frame| frame.render_widget(viewer, frame.area()))?;
-    Ok(())
-}
-```
-
-[`TraceViewer`] intentionally implements [`Widget`] for `&mut TraceViewer`. The viewer must update
-scroll state during rendering because the tail position depends on the rendered height and the
-current number of visible rows. That value is only known once the host application chooses a
-layout area for the widget.
-
-Applications can keep [`TraceViewer`] directly in app state, mutate it through methods such as
-`set_filter`, `scroll_up`, `scroll_down`, `page_up`, `page_down`, `jump_to_oldest`, and
-`jump_to_newest`, and render `&mut viewer` in the area assigned to trace output. The API avoids
-[`StatefulWidget`] while preserving follow-tail and scrollback behavior.
-
-Applications can call [`TraceViewer::status`] to build their own status bars without duplicating
-viewer logic. The returned status includes follow-tail versus scrollback mode, the last computed
-scroll offsets, visible and hidden event counts after display filtering, selected visible row
-state, the active filter, and the underlying `TraceStoreStatus`.
-
-Selection is tracked by retained event id and interpreted through the active display filter.
-Applications can move selection with `select_next`, `select_previous`, `select_first`, and
-`select_last`, then read `selected_event` or [`TraceViewer::status`] for app-owned detail views.
-For rendering full selected-event context, call [`TraceViewer::selected_detail`] and render the returned
-[`TraceEventDetail`] into a caller-owned pane. Compact row rendering remains fmt-like and optimized
-for scanning: short timestamp, level, target, message, and fields.
-[`FormatOptions`] can switch compact rows to full RFC 3339 timestamps or a custom [`chrono`] format.
-[`TraceViewer::set_show_span_context`] enables inline span context for applications that want
-fmt-style span names in compact rows.
-[`TraceViewer::set_show_source_locations`] enables source file and line display in compact rows
-without rebuilding the viewer.
-Detail rendering is where full fields, source location, and span-stack context live. Its styling
-uses a small palette and indentation to show how metadata, fields, and span context relate without
-turning the pane into a color legend.
-[`TraceEventDetail::text`] exposes the formatted detail text for applications that need their
-own scroll state, borders, titles, or layout chrome around the detail pane.
-
-## Current Public Path
-
-- [`TraceLayer`]: subscriber layer for capture.
-- [`TraceStore`]: shared runtime buffer of retained records and storage counters.
-- [`TraceViewer`]: [`ratatui`] event-stream viewer.
-- [`TraceEventDetail`]: renderable selected-event detail.
-- [`TraceFilter`]: display-time event filter.
-- [`FormatOptions`]: compact row formatting options.
-- [`TimingLayer`]: optional span busy/idle timing layer.
-- [`TimingState`]: span timing lifecycle state.
-
-The demo in `examples/demo.rs` is intentionally small and should stay aligned with the public API
-path above.
-
-## Known Limitations
-
-- Aggregation of repeated events is not implemented yet.
-- The default viewer is intentionally simple and does not yet expose secondary span-tree or timing
-  views.
-- The timing layer remains local to this crate. The related upstream [`tracing`] PR did not appear
-  to land as a stable [`tracing-subscriber`] API.
-- Grouped rows are planned follow-up work rather than part of the initial viewer surface.
-
-The follow-up work is tracked in the
-[main trace viewer roadmap](https://github.com/joshka/tui-tracing/issues/22).
-
 ## Maintainer Documentation
 
-- [Architecture overview](docs/architecture.md)
 - [Design and quality standards](docs/standards.md)
 - [Release checklist](docs/release-checklist.md)
 
@@ -229,27 +115,8 @@ The follow-up work is tracked in the
 just ci
 ```
 
-The `rustfmt.toml` matches the formatting posture used by `../async-tty` and requires nightly
-rustfmt for the configured unstable formatting options.
-
-[`formatoptions`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.FormatOptions.html
-[`chrono`]: https://docs.rs/chrono/latest/chrono/
 [`ratatui`]: https://docs.rs/ratatui/latest/ratatui/
-[`statefulwidget`]: https://docs.rs/ratatui/latest/ratatui/widgets/trait.StatefulWidget.html
-[`timinglayer`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TimingLayer.html
-[`timingstate`]: https://docs.rs/tui-tracing/latest/tui_tracing/enum.TimingState.html
-[`traceeventdetail`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceEventDetail.html
-[`traceeventdetail::text`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceEventDetail.html#method.text
-[`tracefilter`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceFilter.html
-[`tracelayer`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceLayer.html
-[`tracestore`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceStore.html
-[`tracestore::status`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceStore.html#method.status
-[`traceviewer`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceViewer.html
-[`traceviewer::selected_detail`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceViewer.html#method.selected_detail
-[`traceviewer::set_show_source_locations`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceViewer.html#method.set_show_source_locations
-[`traceviewer::set_show_span_context`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceViewer.html#method.set_show_span_context
-[`traceviewer::status`]: https://docs.rs/tui-tracing/latest/tui_tracing/struct.TraceViewer.html#method.status
 [`tracing`]: https://docs.rs/tracing/latest/tracing/
-[`tracing-subscriber`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/
+[`tracing_subscriber::Layer`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/trait.Layer.html
 [`tracing_subscriber::fmt`]: https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/
-[`widget`]: https://docs.rs/ratatui/latest/ratatui/widgets/trait.Widget.html
+[`tui-logger`]: https://github.com/gin66/tui-logger

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -99,10 +99,9 @@ Put behavior in `TraceViewer` when it affects default viewer interaction or rend
 - Rendering compact rows and selected-row styling.
 - Producing selected-event detail data for caller-owned detail panes.
 
-`TraceViewer` intentionally implements `Widget` for `&mut TraceViewer` because scroll bounds depend
-on the final render area. Keep terminal raw mode, event loops, key maps, panes, borders, and status
-bar composition in the host application or demo unless the library has a reusable primitive to
-expose.
+`TraceViewer` implements `Widget` for `&mut TraceViewer` because scroll bounds depend on the final
+render area. Keep terminal raw mode, event loops, key maps, panes, borders, and status bar
+composition in the host application or demo unless the library has a reusable primitive to expose.
 
 ## Demo And Application Concerns
 

--- a/docs/standards.md
+++ b/docs/standards.md
@@ -55,8 +55,12 @@ easy to understand, audit, extend, and use correctly.
 ## Documentation Standards
 
 - Treat rustdoc as part of the API, not decoration.
+- Keep the README as a short crate entry page: purpose, quick start, compatibility, positioning or
+  comparison when useful, and links to deeper docs. Put detailed usage models in rustdoc unless the
+  material is maintainer-only.
 - The crate root should route new users with a purpose statement, first example, primary public
-  entry points, module map, feature flags, examples, and lifecycle notes.
+  entry points, module map, feature flags, examples, lifecycle notes, current limitations, and next
+  reading.
 - Every public module should answer what concept it owns, the main workflow, related modules, and
   what it intentionally does not own.
 - Every public type should explain what it represents, who should construct it, what invariants it
@@ -81,6 +85,17 @@ easy to understand, audit, extend, and use correctly.
 - Examples should show practical use, not just construction.
 - Prefer simple, obvious examples over elaborate mini-frameworks.
 - Use realistic examples that teach ownership, lifecycle, errors, or integration shape.
+- Runnable examples should resemble real application wiring. Visual demos may optimize for
+  screenshots or GIFs, but at least one small example should show the modern application lifecycle,
+  event loop, input path, and a realistic reason the crate is useful.
+- Document planned or roadmap-only behavior as current scope or future work, not as available API.
+  Do not describe unimplemented secondary views, retention policies, configuration, or output modes
+  as though users can rely on them today.
+- When a nearby crate, library, or established alternative exists, compare accurately and
+  charitably. Explain fit, scope, and tradeoffs instead of implying the local crate is universally
+  better.
+- Prefer direct ownership and boundary statements over apologetic design justifications. Explain
+  what a type owns, what it mutates, and what the application remains responsible for.
 - Markdown docs should be reserved for material that does not fit in rustdoc or README: quality
   standards, release procedure, design tradeoffs, and maintainer workflows.
 
@@ -104,6 +119,8 @@ easy to understand, audit, extend, and use correctly.
 - Prefer fast, deterministic CI jobs with clear failure modes.
 - Keep required checks strict enough that warnings, broken docs, stale examples, and formatting
   drift do not accumulate.
+- Local command recipes should allow focused variants where practical, such as forwarding extra
+  arguments to documentation or test commands, without weakening the default CI-like recipe.
 - Avoid noisy automation that produces dependency churn or low-signal failures.
 
 ## Baseline Local And CI Checks

--- a/justfile
+++ b/justfile
@@ -1,50 +1,50 @@
 set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
 
-fmt:
-    cargo +nightly fmt --all
+fmt *args:
+    cargo +nightly fmt --all {{ args }}
 
-fmt-check:
-    cargo +nightly fmt --all -- --check
+fmt-check *args:
+    cargo +nightly fmt --all -- --check {{ args }}
 
-check:
-    cargo check --workspace --all-targets --all-features
-    cargo check --workspace --all-targets --no-default-features
+check *args:
+    cargo check --workspace --all-targets --all-features {{ args }}
+    cargo check --workspace --all-targets --no-default-features {{ args }}
 
-test:
-    cargo test --workspace --all-features
-    cargo test --doc --workspace --all-features
-    cargo test --examples --workspace --all-features
+test *args:
+    cargo test --workspace --all-features {{ args }}
+    cargo test --doc --workspace --all-features {{ args }}
+    cargo test --examples --workspace --all-features {{ args }}
 
-clippy:
-    cargo +stable clippy --workspace --all-features --all-targets -- -D warnings
-    cargo +beta clippy --workspace --all-features --all-targets -- -D warnings
+clippy *args:
+    cargo +stable clippy --workspace --all-features --all-targets {{ args }} -- -D warnings
+    cargo +beta clippy --workspace --all-features --all-targets {{ args }} -- -D warnings
 
-doc:
-    RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps
+doc *args:
+    RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps {{ args }}
 
-docs-rs:
-    RUSTDOCFLAGS="-D warnings" cargo +nightly docs-rs
+docs-rs *args:
+    RUSTDOCFLAGS="-D warnings" cargo +nightly docs-rs {{ args }}
 
-markdown:
-    markdownlint-cli2 README.md "docs/**/*.md"
+markdown *args:
+    markdownlint-cli2 README.md "docs/**/*.md" {{ args }}
 
-package:
-    cargo package --workspace --allow-dirty
+package *args:
+    cargo package --workspace --allow-dirty {{ args }}
 
-audit:
-    cargo audit
+audit *args:
+    cargo audit {{ args }}
 
-deny:
-    cargo deny check
+deny *args:
+    cargo deny check {{ args }}
 
-machete:
-    cargo machete
+machete *args:
+    cargo machete {{ args }}
 
-minimal-versions:
-    cargo minimal-versions check --direct --workspace --all-targets --all-features
+minimal-versions *args:
+    cargo minimal-versions check --direct --workspace --all-targets --all-features {{ args }}
 
 ci: fmt-check check test clippy doc docs-rs markdown package audit deny machete minimal-versions
 
-demo-gif:
+demo-gif *args:
     mkdir -p target/vhs
-    env -u NO_COLOR -u CLICOLOR -u CLICOLOR_FORCE -u FORCE_COLOR vhs tapes/demo.tape
+    env -u NO_COLOR -u CLICOLOR -u CLICOLOR_FORCE -u FORCE_COLOR vhs tapes/demo.tape {{ args }}

--- a/src/filter.rs
+++ b/src/filter.rs
@@ -20,8 +20,8 @@ use crate::store::TraceSnapshot;
 
 /// Display-time event filter.
 ///
-/// Filters are intentionally independent from [`tracing_subscriber`] filters. They do
-/// not affect capture, and changing them never loses retained events.
+/// Filters are independent from [`tracing_subscriber`] filters. They do not affect
+/// capture, and changing them never loses retained events.
 ///
 /// Matching is substring-based for targets, text, span names, and field values.
 /// Level matching keeps events whose level is at least as severe as the configured

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,9 +1,9 @@
 //! [`tracing_subscriber`] capture layer.
 //!
 //! [`TraceLayer`] records tracing spans and events into [`crate::TraceStore`]. It
-//! intentionally does not decide what the TUI shows. Applications can combine it
-//! with ordinary [`tracing_subscriber`] capture filters and then apply
-//! [`crate::TraceFilter`] at display time.
+//! does not decide what the TUI shows. Applications can combine it with ordinary
+//! [`tracing_subscriber`] capture filters and then apply [`crate::TraceFilter`] at
+//! display time.
 //!
 //! # Common Workflow
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,55 +1,232 @@
 //! # tui-tracing
 //!
-//! `tui-tracing` provides a runtime store and [`ratatui`] widget for displaying
-//! [`tracing`] events inside a [`ratatui`]-based application. It captures native
-//! tracing spans and events, retains them in [`TraceStore`], and renders them as a
-//! [`tracing_subscriber::fmt`](mod@tracing_subscriber::fmt)-style event stream with
-//! [`TraceViewer`]. It is intentionally tracing-first: it does not adapt through the `log` crate,
-//! and display-time filtering is separate from subscriber capture filtering.
+//! `tui-tracing` provides a runtime store and [`ratatui`] widget for showing
+//! [`tracing`] output inside a TUI application.
 //!
-//! Use this crate when an application needs tracing diagnostics available inside
-//! its own [`ratatui`] UI at runtime. The primary path is:
-//! capture with [`TraceLayer`], retain in [`TraceStore`], filter with
-//! [`TraceFilter`], and render with [`TraceViewer`].
+//! The default viewer is an event stream shaped like
+//! [`tracing_subscriber::fmt`](mod@tracing_subscriber::fmt): timestamp, level,
+//! target, message, and structured fields. The store keeps native tracing records
+//! behind that compact view so applications can inspect span context, source
+//! locations, timing data, and selected-event detail without leaving the terminal UI.
 //!
 //! # Start Here
 //!
-//! Install [`TraceLayer`] in your subscriber, keep a [`TraceViewer`] in application
-//! state, and render it in the area where your application wants trace output.
+//! Install [`TraceLayer`] in your subscriber, keep [`TraceViewer`] in application
+//! state, and render it in the part of your layout that should show trace output.
 //!
-//! ```
-//! use ratatui::DefaultTerminal;
+//! ```no_run
+//! use ratatui::{DefaultTerminal, Frame};
 //! use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 //! use tui_tracing::{TraceLayer, TraceViewer};
 //!
+//! # fn main() -> std::io::Result<()> {
 //! let (layer, store) = TraceLayer::new();
-//! let _ = tracing_subscriber::registry().with(layer).try_init();
+//! tracing_subscriber::registry().with(layer).init();
 //!
-//! let mut viewer = TraceViewer::new(store);
+//! let traces = TraceViewer::new(store);
+//! let mut app = App { traces };
+//! ratatui::run(|terminal| app.run(terminal))
+//! # }
 //!
-//! fn render(terminal: &mut DefaultTerminal, viewer: &mut TraceViewer) -> std::io::Result<()> {
-//!     terminal.draw(|frame| frame.render_widget(viewer, frame.area()))?;
-//!     Ok(())
+//! struct App {
+//!     traces: TraceViewer,
 //! }
 //!
-//! tracing::info!(target: "demo", answer = 42, "ready");
+//! impl App {
+//!     fn run(&mut self, terminal: &mut DefaultTerminal) -> std::io::Result<()> {
+//!         tracing::info!(target: "demo", peer = "alpha", "connected");
+//!         terminal.draw(|frame| self.render(frame))?;
+//!         Ok(())
+//!     }
+//!
+//!     fn render(&mut self, frame: &mut Frame) {
+//!         frame.render_widget(&mut self.traces, frame.area());
+//!     }
+//! }
 //! ```
 //!
-//! For a runnable application-style version of this workflow, run
-//! `cargo run --example basic`. For the visual demo used by the README GIF, run
-//! `cargo run --example demo`.
+//! For a runnable application-style example, run `cargo run --example basic`.
+//! For a more visual demo, run `cargo run --example demo`.
 //!
 //! # When To Use It
 //!
-//! Use this crate when your application already uses [`tracing`] or wants
-//! structured runtime diagnostics in its own [`ratatui`] UI. `tui-tracing` captures
-//! native spans, events, fields, targets, source locations, and span context through
-//! [`tracing_subscriber`].
+//! Use this crate when a Ratatui application already emits [`tracing`] events and
+//! should expose those diagnostics inside the UI. It is useful for developer tools,
+//! demos, long-running terminal applications, and debug panes where switching to a
+//! separate log file or terminal stream would break the workflow.
 //!
-//! This is not a `log` compatibility viewer and does not install a subscriber for
-//! you. It can be installed beside a normal
-//! [`tracing_subscriber::fmt`](mod@tracing_subscriber::fmt) layer when an
-//! application wants both an in-app trace view and ordinary file or stdout logs.
+//! `tui-tracing` does not install a subscriber for you, does not manage terminal
+//! raw mode, and does not replace normal file or stdout logging. Install
+//! [`TraceLayer`] beside a regular
+//! [`tracing_subscriber::fmt`](mod@tracing_subscriber::fmt) layer when the
+//! application wants both in-app diagnostics and durable logs.
+//!
+//! # How The Pieces Fit
+//!
+//! The crate separates capture, storage, filtering, and rendering:
+//!
+//! - [`TraceLayer`] is the [`tracing_subscriber::Layer`] that receives tracing callbacks and writes
+//!   records into a [`TraceStore`].
+//! - [`TraceStore`] is a cloneable, synchronized buffer of retained events and spans. It is the
+//!   handoff between subscriber callbacks and UI rendering.
+//! - [`TraceViewer`] owns one Ratatui view of a store: scrollback, follow-tail mode, selection, row
+//!   options, and the active [`TraceFilter`].
+//! - [`TraceFilter`] hides or shows retained events at display time. Changing it does not remove
+//!   records from the store.
+//!
+//! This split gives applications two levels of filtering. Use ordinary
+//! [`tracing_subscriber`] filters when noisy records should never reach the store.
+//! Use [`TraceFilter`] when the user is exploring records that have already been
+//! captured.
+//!
+//! ```no_run
+//! use tracing_subscriber::Layer;
+//! use tracing_subscriber::filter::LevelFilter;
+//! use tracing_subscriber::layer::SubscriberExt;
+//! use tui_tracing::{TraceFilter, TraceLayer, TraceViewer};
+//!
+//! let (layer, store) = TraceLayer::new();
+//! let subscriber = tracing_subscriber::registry()
+//!     // Capture-time filter: DEBUG never reaches TraceStore.
+//!     .with(layer.with_filter(LevelFilter::INFO));
+//!
+//! let mut viewer = TraceViewer::new(store);
+//! // Display-time filter: retained INFO events can be hidden or shown later.
+//! viewer.set_filter(TraceFilter::all().with_min_level(tracing::Level::WARN));
+//! # let _ = subscriber;
+//! ```
+//!
+//! # Driving The Viewer
+//!
+//! [`TraceViewer`] is application state and implements
+//! [`ratatui::widgets::Widget`] for `&mut TraceViewer`. Rendering updates the
+//! scroll bounds because follow-tail and scrollback depend on the final layout
+//! area.
+//!
+//! Applications decide their own key map and call viewer methods from input
+//! handlers:
+//!
+//! ```
+//! use tui_tracing::{TraceStore, TraceViewer};
+//!
+//! let store = TraceStore::default();
+//! let mut viewer = TraceViewer::new(store);
+//!
+//! viewer.scroll_up(1);
+//! viewer.page_down();
+//! viewer.jump_to_newest();
+//!
+//! viewer.select_next();
+//! viewer.reveal_selection();
+//! ```
+//!
+//! Use [`TraceViewer::status`] for status bars and [`TraceViewer::selected_detail`]
+//! for a caller-owned detail pane:
+//!
+//! ```
+//! use tracing::subscriber;
+//! use tracing_subscriber::Registry;
+//! use tracing_subscriber::layer::SubscriberExt;
+//! use tui_tracing::{TraceLayer, TraceViewer};
+//!
+//! let (layer, store) = TraceLayer::new();
+//! let subscriber = Registry::default().with(layer);
+//!
+//! subscriber::with_default(subscriber, || {
+//!     tracing::warn!(status = 503, "retrying request");
+//! });
+//!
+//! let mut viewer = TraceViewer::new(store);
+//! viewer.select_first();
+//!
+//! let status = viewer.status();
+//! assert_eq!(status.visible_events, 1);
+//!
+//! let detail = viewer.selected_detail().expect("selected event");
+//! assert!(detail.text().to_string().contains("retrying request"));
+//! ```
+//!
+//! # Event Rows And Detail
+//!
+//! The default event row uses a short local timestamp so recent events fit inside
+//! an application pane:
+//!
+//! <pre><code><span style="color:#7f8490">12:04:31.123</span> <span
+//! style="color:#8bd5ca;font-weight:700">INFO </span> <span style="color:#7f8490">app::net:</span>
+//! connected peer=alpha latency_ms=12 <span style="color:#7f8490">12:04:32.018</span> <span
+//! style="color:#eed49f;font-weight:700">WARN </span> <span style="color:#7f8490">app::sync:</span>
+//! retrying attempt=2 error=timeout</code></pre>
+//!
+//! Span context and source locations are captured even when compact rows hide
+//! them. Applications can show those fields inline when the extra width is useful:
+//!
+//! ```
+//! use tui_tracing::{TraceStore, TraceViewer};
+//!
+//! let store = TraceStore::default();
+//! let mut viewer = TraceViewer::new(store);
+//!
+//! viewer.set_show_span_context(true);
+//! viewer.set_show_source_locations(true);
+//! ```
+//!
+//! Selected-event detail is where complete metadata, fields, span stack, span
+//! fields, lifecycle state, and timing live. Applications can render
+//! [`TraceEventDetail`] directly or use [`TraceEventDetail::text`] when they want
+//! their own borders, layout, or scroll state.
+//!
+//! # Retention And Status
+//!
+//! Event retention is bounded. [`TraceStore::default`] keeps the newest 10,000
+//! events, and [`TraceStore::with_capacity`] can choose a different event
+//! capacity. When the event buffer is full, the oldest retained event is evicted
+//! before the new event is inserted. A zero-capacity store counts captured events
+//! as dropped instead of retaining them.
+//!
+//! Span records are retained for context until the store is cleared. This keeps
+//! selected-event detail useful even after spans close, but it also means
+//! long-running applications should choose capacity and clearing behavior
+//! deliberately.
+//!
+//! [`TraceStore::status`] exposes storage counters before display-time filtering:
+//! configured capacity, retained events, retained spans, captured events, accepted
+//! events, evicted events, and dropped events. Hiding an event with
+//! [`TraceFilter`] does not change those counters. [`TraceViewer::status`] adds
+//! view-specific state such as follow-tail versus scrollback mode, scroll offsets,
+//! visible and hidden event counts, selection, and the active filter.
+//!
+//! # Optional Timing
+//!
+//! [`TimingLayer`] can record span busy and idle timing. Install it alongside
+//! [`TraceLayer`] when span timing matters for detail views or custom diagnostics:
+//!
+//! ```no_run
+//! use tracing_subscriber::layer::SubscriberExt;
+//! use tracing_subscriber::util::SubscriberInitExt;
+//! use tui_tracing::{TimingLayer, TraceLayer};
+//!
+//! let (trace_layer, _store) = TraceLayer::new();
+//!
+//! tracing_subscriber::registry()
+//!     .with(TimingLayer)
+//!     .with(trace_layer)
+//!     .init();
+//! ```
+//!
+//! # What To Read Next
+//!
+//! - [`layer`] explains subscriber integration.
+//! - [`store`] documents retention, snapshots, clearing, and storage counters.
+//! - [`viewer`] documents scrolling, selection, status, detail rendering, and row controls.
+//! - [`filter`] documents display-time matching rules.
+//! - [`record`] and [`field`] define the retained record data available to custom views.
+//!
+//! # Current Scope
+//!
+//! The default viewer is event-stream-first. It is not a span tree, and
+//! aggregation of repeated events is not implemented yet. Future span-tree,
+//! timing-summary, and aggregation views should build on the same retained records
+//! without changing the compact event stream into the primary nesting view.
 //!
 //! # Compatibility
 //!
@@ -58,89 +235,10 @@
 //! - Backend: the public API is a Ratatui widget. The examples use crossterm through Ratatui's
 //!   `ratatui::run` helper.
 //!
-//! # Core Concepts
-//!
-//! - [`TraceLayer`] captures structured tracing records.
-//! - [`TraceStore`] retains those records for runtime inspection and exposes storage counters
-//!   through [`TraceStore::status`].
-//! - [`TraceFilter`] filters retained records at display time without losing data.
-//! - [`FormatOptions`] controls compact event-row formatting.
-//! - [`TraceViewer`] renders the event-stream view and owns scroll/filter state.
-//! - [`TraceEventDetail`] renders full detail for one selected event.
-//! - [`TimingLayer`] optionally records span busy/idle timing.
-//!
-//! # Module Map
-//!
-//! - [`layer`] owns [`tracing_subscriber`] integration.
-//! - [`store`] owns retained runtime data and storage counters.
-//! - [`viewer`] owns Ratatui rendering state.
-//! - [`filter`] owns display-time matching.
-//! - [`record`] owns captured event and span record shapes.
-//! - [`field`] owns structured field values.
-//!
-//! Span trees, timing summaries, and aggregation are secondary views built on the
-//! same stored records. The default view stays event-stream-first because recent
-//! event output is the diagnostic surface users already know from
-//! [`tracing_subscriber::fmt`](mod@tracing_subscriber::fmt).
-//!
-//! # Runtime And Lifecycle
-//!
-//! [`TraceLayer`] is a [`tracing_subscriber::Layer`]. It captures records only
-//! while installed in the active subscriber. [`TraceStore`] is an in-memory,
-//! cloneable handle backed by synchronization, so capture and rendering can run on
-//! different threads.
-//!
-//! [`TraceViewer`] is application state. It intentionally implements
-//! [`ratatui::widgets::Widget`] for `&mut TraceViewer` because scrollback and
-//! follow-tail state depend on the render area and can only be clamped correctly
-//! during rendering.
-//!
-//! This crate does not install a global subscriber by itself, does not spawn
-//! background tasks, and does not manage terminal raw mode. Those lifecycle
-//! concerns remain owned by the application.
-//!
 //! # Feature Flags
 //!
 //! This crate currently has no feature flags. All public APIs are available with
 //! default dependencies.
-//!
-//! # Viewer Surface
-//!
-//! [`TraceViewer`] renders the default event-stream surface. It is meant to
-//! answer one question quickly: what just happened in the application?
-//!
-//! The viewer is not a span tree. Span nesting is retained as event context and
-//! can be shown in compact rows when useful, but rows default to the same
-//! event-first shape as [`tracing_subscriber::fmt`](mod@tracing_subscriber::fmt):
-//! timestamp, level, target, message, and fields.
-//!
-//! Compact rows default to [`TimestampFormat::ShortLocal`] so recent events fit
-//! inside an application pane:
-//!
-//! ```text
-//! 12:04:31.123 INFO  app::net: connected peer=alpha latency_ms=12
-//! 12:04:32.018 WARN  app::sync: retrying attempt=2 error=timeout
-//! ```
-//!
-//! Display-time filtering is handled by [`TraceFilter`], so applications can
-//! narrow the visible events without dropping retained records. The current
-//! filter supports minimum level, target substring, span-name substring,
-//! free-text matching, and exact field-name plus text-value matching.
-//!
-//! [`TraceViewer`] owns the interaction state needed to render this stream:
-//! follow-tail versus scrollback mode, scroll position, selected event, source
-//! location visibility, span-context visibility, and the active filter.
-//! Applications bind their own input model to methods such as
-//! [`TraceViewer::scroll_up`], [`TraceViewer::scroll_down`],
-//! [`TraceViewer::page_up`], [`TraceViewer::page_down`],
-//! [`TraceViewer::jump_to_oldest`], [`TraceViewer::jump_to_newest`],
-//! [`TraceViewer::select_previous`], and [`TraceViewer::select_next`].
-//!
-//! [`TraceViewer::status`] exposes the current view state and underlying storage
-//! counters for application-owned status bars. [`TraceViewer::selected_detail`]
-//! returns the full detail surface for the selected event, including complete
-//! timestamp, target, module path, source location, event fields, span stack,
-//! span fields, lifecycle state, and timing when available.
 
 #![forbid(unsafe_code)]
 #![deny(rustdoc::bare_urls)]

--- a/src/store.rs
+++ b/src/store.rs
@@ -42,8 +42,8 @@ const DEFAULT_EVENT_CAPACITY: usize = 10_000;
 ///
 /// The store is cheap to clone and is safe to share between the tracing layer and
 /// the TUI runtime. Events are retained in insertion order up to the configured
-/// capacity. Spans are retained while referenced by retained events or until the
-/// application explicitly clears the store.
+/// capacity. Span metadata is retained until the application explicitly clears the
+/// store.
 ///
 /// `TraceStore` does not perform I/O and does not spawn background work. Dropping
 /// the final clone drops all retained records.

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -932,9 +932,9 @@ pub enum TraceScrollMode {
 
 /// Structured status summary for app-owned trace viewer chrome.
 ///
-/// This type intentionally carries data, not formatted text. Applications can use
-/// it to build status bars, headers, telemetry, or tests without coupling to the
-/// library's demo wording.
+/// This type carries data, not formatted text. Applications can use it to build
+/// status bars, headers, telemetry, or tests without coupling to the library's
+/// demo wording.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TraceViewStatus {
     /// Current scroll behavior.


### PR DESCRIPTION
## Summary

- Tighten the README into a shorter crate entry page and point deeper usage details to docs.rs.
- Rewrite the crate-level Rustdoc landing page with checked examples for setup, data flow, viewer interaction, event rows, detail, retention, timing, feature flags, and next reading.
- Align supporting docs with the writing standards and clarify span retention behavior.
- Allow `just` recipes to forward command arguments, including `just doc --open` and `just docs-rs --open`.

## Validation

- `cargo test --doc --workspace --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`
- `markdownlint-cli2 README.md docs/architecture.md docs/standards.md`
- `just markdown`
